### PR TITLE
Add project lifecycle management (resolve + archive)

### DIFF
--- a/commands/vine/evolve.md
+++ b/commands/vine/evolve.md
@@ -48,7 +48,9 @@ ship — every feature is an opportunity to grow on three dimensions.
 
 Identify the feature directory under `.vine/projects/` (e.g., `.vine/projects/payments/webhook-support/`). If
 there are multiple feature directories, use `AskUserQuestion` to let the engineer pick which
-feature to review.
+feature to review. Filter out resolved projects (directories containing a `.resolved` file) and
+archived projects (under `.vine/projects/.archive/`). If all projects are resolved or archived,
+tell the engineer and suggest starting a new cycle with `vine:verify`.
 
 Read all VINE artifacts for this feature:
 - `.vine/projects/<domain>/<feature-slug>/CONTEXT.md` (the landscape)
@@ -375,6 +377,21 @@ Compile everything into `.vine/projects/<domain>/<feature-slug>/EVOLUTION.md`:
    "Grow features on solid roots."
 ---
 ```
+
+### Mark as Resolved
+
+After presenting the completion block, offer to mark the project as resolved using
+`AskUserQuestion`:
+
+> "This VINE cycle is complete. Want to mark this project as resolved? Resolved projects
+> are filtered out of future command prompts but stay accessible by explicit path."
+
+Options (mutually exclusive):
+1. "Mark resolved (Recommended)" — "Add .resolved marker to this project directory"
+2. "Keep active" — "Leave the project in active state for now"
+
+If the engineer chooses to resolve, write an empty `.resolved` file to
+`.vine/projects/<domain>/<feature-slug>/.resolved`.
 
 ## Important Principles
 

--- a/commands/vine/inquire.md
+++ b/commands/vine/inquire.md
@@ -59,8 +59,11 @@ decide, and document everything. The output is a SPEC.md that vine:navigate can 
 ### 1. Load the Context
 
 Identify the feature directory under `.vine/projects/`. Look for the domain/feature-slug path
-(e.g., `.vine/projects/payments/webhook-support/`). If there's only one feature directory, use that.
-If there are multiple, use `AskUserQuestion` to let the engineer pick which feature to work on.
+(e.g., `.vine/projects/payments/webhook-support/`). Filter out resolved projects (directories
+containing a `.resolved` file) and archived projects (under `.vine/projects/.archive/`). If
+there's only one active feature directory, use that. If there are multiple, use
+`AskUserQuestion` to let the engineer pick which feature to work on. If all projects are
+resolved or archived, tell the engineer and suggest starting a new cycle with `vine:verify`.
 
 Read `.vine/projects/<domain>/<feature-slug>/CONTEXT.md` from the project. If it doesn't exist, tell the engineer:
 

--- a/commands/vine/navigate.md
+++ b/commands/vine/navigate.md
@@ -73,7 +73,9 @@ your approach, and teaching you things about the domain that make the implementa
 
 Identify the feature directory under `.vine/projects/` (e.g., `.vine/projects/payments/webhook-support/`). If
 there are multiple feature directories, use `AskUserQuestion` to let the engineer pick which
-feature to work on.
+feature to work on. Filter out resolved projects (directories containing a `.resolved` file) and
+archived projects (under `.vine/projects/.archive/`). If all projects are resolved or archived,
+tell the engineer and suggest starting a new cycle with `vine:verify`.
 
 Read `.vine/projects/<domain>/<feature-slug>/CONTEXT.md` and `.vine/projects/<domain>/<feature-slug>/SPEC.md`. If either is
 missing, tell the engineer which prior phase needs to run first.

--- a/references/STATE.md
+++ b/references/STATE.md
@@ -218,6 +218,40 @@ Not all VINE commands produce state artifacts. `vine:pair` is a lightweight mode
 
 Artifact-free commands still follow the structural conventions (frontmatter, hooks, profile loading) — they just don't participate in the state artifact chain.
 
+## Project Lifecycle
+
+VINE projects progress through an implicit lifecycle: active → resolved → archived. By default, all projects are active. The lifecycle is opt-in — projects without markers behave exactly as they always have.
+
+### Resolved
+
+After `vine:evolve` completes, the engineer can mark a project as resolved by placing a `.resolved` marker file in the project directory:
+
+```
+.vine/projects/<domain>/<feature-slug>/.resolved
+```
+
+The file is empty — its presence is the signal. Commands that list feature directories (inquire, navigate, evolve) filter out resolved projects from `AskUserQuestion` prompts. Resolved projects are still accessible by explicit path.
+
+### Archived
+
+Archiving moves a resolved project to `.vine/projects/.archive/`:
+
+```
+.vine/projects/.archive/<domain>/<feature-slug>/
+```
+
+This gets completed work fully out of the way while preserving artifacts. Archiving is manual — VINE doesn't auto-archive.
+
+### Filtering Convention
+
+Commands that present feature directory lists via `AskUserQuestion` must:
+
+1. Skip directories containing a `.resolved` file
+2. Skip anything under `.vine/projects/.archive/`
+3. If all projects are resolved/archived, tell the engineer and suggest starting a new cycle with `vine:verify`
+
+If the engineer needs to access a resolved project, they can pass its path explicitly as an argument.
+
 ## Chaining Protocol
 
 Each phase ends with a **Next Step Suggestion** that tells the user exactly what to run next and why. Each phase also suggests starting a fresh session (`/clear`) so state flows through `.vine/` files rather than chat context:


### PR DESCRIPTION
## What

Add a project lifecycle convention so completed VINE projects can be marked as resolved and optionally archived. Introduces a `.resolved` marker file, filtering in commands that list feature directories, and a resolve prompt at the end of `vine:evolve`.

## Why

VINE projects in `.vine/projects/` have no lifecycle state — completed features show up alongside active ones when commands list directories. As engineers run more VINE cycles, the project list grows without a way to declutter it.

Closes #15

## How to test

1. Run `vine:evolve` on a project — after the completion block, it should offer to mark the project as resolved
2. Place an empty `.resolved` file in a `.vine/projects/<domain>/<feature>/` directory, then run `vine:inquire` or `vine:navigate` — that project should be filtered out of the selection prompt
3. Run `/trellis` — all 6 commands should pass all checks
4. Read `references/STATE.md` — the "Project Lifecycle" section should document the `.resolved` marker, archive path, and filtering convention

## Checklist

- [ ] I've tested this in an actual VINE cycle (if changing command behavior)
- [x] Changes are focused on a single concern
- [x] Any new behavior is documented in the README or command file