### PR TITLE
Update README ASCII diagram to include vine:pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ VINE is for engineers who want to stay engaged with their code, not delegate it 
 vine:verify  →  vine:inquire  →  vine:navigate  →  vine:evolve
    📡              📐               🧭                🌱
  Explore         Design           Build            Grow
+
+         ╰─────── vine:pair ───────╯
+                     🤝
+                Quick changes
 ```
 
 ### vine:verify — Context Building Spike


### PR DESCRIPTION
## What

Adds `vine:pair` to the README's four-phase ASCII diagram as a visual shortcut path beneath the main flow.

## Why

The diagram only showed the four full-cycle phases. `vine:pair` was described narratively below but not represented visually, making it easy to miss at a glance.

Closes #18

## How to test

Open `README.md` and verify the ASCII diagram renders correctly with `vine:pair` shown as an alternative path beneath the main chain.

## Checklist

- [ ] ~~I've tested this in an actual VINE cycle~~ (no command behavior change)
- [x] Changes are focused on a single concern
- [x] Any new behavior is documented in the README or command file