### PR TITLE
Fix publish workflow for npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org
+          node-version: 22
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Verify package version matches release tag
         run: |


### PR DESCRIPTION
## What

Fixes the GitHub Actions publish workflow to work with npm trusted publishing (OIDC).

- Bump Node from 20 to 22 (npm 10.x → 11.x)
- Remove `registry-url` (not needed for OIDC-based auth)
- Add `npm install -g npm@latest` to ensure latest npm with trusted publishing support

## Why

The v0.1.0 release workflow failed with a 404 because npm 10.8.2 (shipped with Node 20) doesn't support trusted publishing. npm >= 11.5.1 is required.

## How to test

Merge, bump package.json to 0.2.0, create a GitHub release tagged v0.2.0, and verify the workflow publishes successfully.

## Checklist

- [ ] I've tested this in an actual VINE cycle (if changing command behavior)
- [x] Changes are focused on a single concern
- [x] Any new behavior is documented in the README or command file