### PR TITLE
Add artifact preview docs with glow hook setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,10 @@ Most AI coding frameworks optimize for autonomous speed — the AI writes code, 
 | **Best for** | Greenfield / scripted tasks | Established codebases |
 | **Learning model** | One-way (AI executes) | Two-way (both learn) |
 
+## Tips
+
+- [Auto-preview artifacts with glow](docs/artifact-preview.md) — opens a formatted terminal preview when VINE writes phase artifacts
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. The short version: open an issue or [Discussion](../../discussions) before submitting a PR.

--- a/docs/artifact-preview.md
+++ b/docs/artifact-preview.md
@@ -1,0 +1,103 @@
+# Auto-Preview Artifacts with Glow
+
+VINE phase artifacts (CONTEXT.md, SPEC.md, NAVIGATION.md, EVOLUTION.md) are easier to review with terminal rendering. This guide sets up a Claude Code hook that automatically opens a formatted preview window whenever an artifact is written.
+
+Scroll with arrow keys or `j`/`k`, press `q` to close.
+
+## Prerequisites
+
+Install [glow](https://github.com/charmbracelet/glow) (terminal markdown renderer) and [jq](https://jqlang.github.io/jq/) (JSON parser):
+
+```bash
+brew install glow jq
+```
+
+## 1. Create the Hook Script
+
+Save one of the scripts below to `.vine/hooks/artifact-preview.sh` (project-level) or `~/.claude/hooks/vine-artifact-preview.sh` (global).
+
+### iTerm2
+
+```bash
+#!/bin/bash
+INPUT=$(cat)
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+BASENAME=$(basename "$FILE" 2>/dev/null)
+case "$BASENAME" in
+  CONTEXT.md|SPEC.md|NAVIGATION.md|EVOLUTION.md|PAUSE.md) ;;
+  *) exit 0 ;;
+esac
+
+osascript <<EOF
+tell application "iTerm2"
+  create window with default profile
+  tell current session of current window
+    write text "glow -p \"$FILE\"; exit"
+  end tell
+end tell
+EOF
+
+exit 0
+```
+
+### Terminal.app
+
+```bash
+#!/bin/bash
+INPUT=$(cat)
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+BASENAME=$(basename "$FILE" 2>/dev/null)
+case "$BASENAME" in
+  CONTEXT.md|SPEC.md|NAVIGATION.md|EVOLUTION.md|PAUSE.md) ;;
+  *) exit 0 ;;
+esac
+
+osascript <<EOF
+tell application "Terminal"
+  do script "glow -p \"$FILE\"; exit"
+  activate
+end tell
+EOF
+
+exit 0
+```
+
+### Make it executable
+
+```bash
+chmod +x .vine/hooks/artifact-preview.sh
+```
+
+## 2. Register the Hook
+
+Add a `PostToolUse` entry to your Claude Code settings.
+
+- **Project-level:** `.claude/settings.local.json` (gitignored, this project only)
+- **Global:** `~/.claude/settings.json` (all projects)
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/absolute/path/to/artifact-preview.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Replace the command path with the absolute path to your script. If you already have `PostToolUse` entries in your settings, add the new entry to the existing array — don't replace it.
+
+## How It Works
+
+When Claude writes a CONTEXT.md, SPEC.md, NAVIGATION.md, or EVOLUTION.md file, the hook fires and opens a new terminal window with a glow-rendered preview. Other `.md` files are ignored.


### PR DESCRIPTION
## Summary

- Adds `docs/artifact-preview.md` with setup guide for auto-previewing VINE phase artifacts using glow + Claude Code hooks
- Includes hook scripts for iTerm2 and Terminal.app
- Links from README Tips section

## Test plan

- [ ] Follow the setup guide on a fresh machine
- [ ] Verify hook triggers on CONTEXT.md, SPEC.md, NAVIGATION.md, EVOLUTION.md, PAUSE.md writes
- [ ] Verify hook ignores other .md files
- [ ] Test both iTerm2 and Terminal.app scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)