### PR TITLE
chore: archive superseded tool-graph project

### DIFF
--- a/.vine/projects/.archive/commands/tool-graph/CONTEXT.md
+++ b/.vine/projects/.archive/commands/tool-graph/CONTEXT.md
@@ -1,0 +1,70 @@
+# Feature Context: Tool Graph
+## Date: 2026-04-06
+## Author: Rob Bruhn + Claude
+
+### Codebase Landscape
+
+**Commands (the primary graph unit):**
+- 10 VINE command files in `commands/vine/` with consistent YAML frontmatter: `name`, `description`, `argument-hint`, `allowed-tools`
+- 3 contributor tools in `.claude/commands/`: trellis, triage, pr
+- Commands reference each other extensively in prose but have no structured relationship metadata
+- `allowed-tools` field is the only structured relationship data — which tools a command can use
+
+**Existing relationship patterns already in the codebase:**
+- Phase sequence: verify -> inquire -> navigate -> evolve (artifact chain via CONTEXT.md -> SPEC.md -> NAVIGATION.md -> EVOLUTION.md)
+- Lateral: verify <-> pair (scope switch), navigate <-> pause, pause <-> resume
+- Hub commands: help/status/init connect to everything
+- Cross-references are implicit — commands mention other commands in their prose, not structured metadata
+
+**Skills and MCP servers:**
+- `.claude/skills/` is referenced by init's discovery but no skill files exist in this repo
+- `.claude/settings.json` / `.claude/settings.local.json` can define MCP servers providing additional tools
+- Skills use the same .md + YAML frontmatter pattern as commands
+
+**Installation path:**
+- `bin/cli.js` copies command .md files to `.claude/commands/vine/` (local) or `~/.claude/commands/vine/` (global)
+- Only copies files — no graph generation at install time
+- Upgrade path suggests running `/vine:init` to discover new tools
+
+**Hook system:**
+- `.vine/hooks/shared.md` loaded by all phases — contains command inventory, conventions, CI/CD
+- Per-phase hooks (verify.md, navigate.md, evolve.md, pair.md) add phase-specific instructions
+- Hooks are prose instructions, not structured data — the graph would provide the structured layer hooks draw from
+
+### Current State
+
+- Init's Step 1 (Discover Repo Capabilities) scans `.claude/commands/`, `.claude/skills/`, settings files, but persists findings only as prose in shared.md
+- Help hardcodes the command list as a text block — no dynamic generation from structured data
+- Evolve's Evolution 2 suggests skills, hook updates, and workflow improvements but without graph-informed context
+- No mechanism exists to discover relationships between commands across repos — each init starts from scratch
+
+### Edge Cases & Tribal Knowledge
+
+- **VINE IS the product.** Editing a command file changes the tool itself. `vine:graph` will be a command that describes other commands — including potentially itself. Self-referential edge case.
+- **Global vs local installs.** Commands can live in `~/.claude/commands/vine/` (global) or `.claude/commands/vine/` (local). Graph generation needs to handle both, plus non-VINE commands in `.claude/commands/`.
+- **Command addition checklist.** Adding an 11th command requires updates to: CLAUDE.md (command count + list), README.md (command references), shared.md (command list), verify.md hook (command count reference). This is documented in shared.md hooks.
+- **Pure markdown philosophy.** No build step, no runtime code. The issue proposed YAML workflow files but we've decided on markdown templates to stay consistent.
+- **"Enhances any repo even if VINE were removed."** The standalone artifact (`.claude/TOOL-GRAPH.md`) must be useful for any Claude Code user. VINE-specific outputs (`.vine/workflows/`, hook suggestions) are the value-add layer.
+
+### Tech Debt in Affected Areas
+
+- **Init's discovery is unstructured.** Step 1 scans for capabilities but has no intermediate structured representation. Graph generation would benefit from a structured discovery pass that both the graph and hook generation can consume.
+- **Help's hardcoded command list.** Could reference TOOL-GRAPH.md instead of maintaining a separate list, but this creates a dependency on the graph existing.
+- **Shared.md duplicates discoverable info.** The "Available Tools & Agents" section in shared.md is essentially a manually-maintained version of what the graph would auto-generate.
+
+### Documentation Gaps
+
+- No documentation for `.claude/skills/` format — VINE references it in init but doesn't define the convention (Claude Code defines it)
+- README doesn't mention command relationships or discoverability beyond the linear phase chain
+- `references/STATE.md` would need a section for TOOL-GRAPH.md if it becomes a managed artifact
+- No documentation for workflow templates (new concept with this feature)
+
+### Open Questions
+
+1. **TOOL-GRAPH.md format**: What sections should it contain? Mermaid diagram + relationship table + inventory is the starting point, but what else makes it "standalone useful"?
+2. **Workflow template format**: Markdown files in `.vine/workflows/` — what frontmatter fields? How does a workflow reference steps that are commands vs manual actions?
+3. **Init integration depth**: Does init just call `vine:graph` as a subprocess, or does it inline the graph logic? The former is cleaner but adds a dependency between commands.
+4. **Evolve integration**: Should evolve automatically re-run graph generation after suggesting new skills/commands, or just suggest running `vine:graph`?
+5. **Non-VINE repos**: When `vine:graph` runs on a repo without `.vine/`, should it still produce TOOL-GRAPH.md? (Yes — that's the standalone value prop. But should it also offer to create `.vine/workflows/`?)
+6. **Graph staleness**: TOOL-GRAPH.md is a generated artifact. When commands change, the graph goes stale. Should there be a staleness check? Or is "run vine:graph to update" sufficient?
+7. **Scope for this cycle**: The issue includes auto-suggestion hooks (UserPromptSubmit). Is that in scope or a follow-up? It's the most complex piece and may warrant its own cycle.

--- a/.vine/projects/.archive/commands/tool-graph/PROJECT-MAP.md
+++ b/.vine/projects/.archive/commands/tool-graph/PROJECT-MAP.md
@@ -1,6 +1,7 @@
 # Project Map: Tool Graph
-## Feature: .vine/projects/commands/tool-graph
+## Feature: .vine/projects/commands/tool-graph (archived → .vine/projects/.archive/commands/tool-graph)
 ## Created: 2026-04-06
+## Status: 🪦 Superseded — shipped as vine:optimize (PR #38, v0.3.0); archived in PR #73
 
 ### VINE Progress
 
@@ -8,5 +9,5 @@
 |-------|--------|---------|
 | verify | ✅ | 2026-04-06 |
 | inquire | ✅ | 2026-04-06 |
-| navigate | 🚧 | 2026-04-06 |
-| evolve | ⬜ | — |
+| navigate | 🪦 superseded | 2026-04-06 |
+| evolve | — (n/a) | — |

--- a/.vine/projects/.archive/commands/tool-graph/PROJECT-MAP.md
+++ b/.vine/projects/.archive/commands/tool-graph/PROJECT-MAP.md
@@ -1,0 +1,12 @@
+# Project Map: Tool Graph
+## Feature: .vine/projects/commands/tool-graph
+## Created: 2026-04-06
+
+### VINE Progress
+
+| Phase | Status | Updated |
+|-------|--------|---------|
+| verify | ✅ | 2026-04-06 |
+| inquire | ✅ | 2026-04-06 |
+| navigate | 🚧 | 2026-04-06 |
+| evolve | ⬜ | — |

--- a/.vine/projects/.archive/commands/tool-graph/SPEC.md
+++ b/.vine/projects/.archive/commands/tool-graph/SPEC.md
@@ -3,6 +3,15 @@
 ## Built on: CONTEXT.md (2026-04-06)
 ## Decisions made by: Rob Bruhn
 
+> **⚠️ Archived — superseded, not abandoned.** This spec was never implemented under the
+> `vine:graph` name. The design evolved during navigate and shipped as **`vine:optimize`**
+> ([PR #38](https://github.com/moduloMoments/VINE/pull/38), v0.3.0) — which delivers this
+> spec's intent (skill-matching description scoring, workflow-chain/routing context, token
+> efficiency) without the `vine:graph` command or a separate graph artifact. The "structured
+> relationship metadata" idea here was dropped in favor of optimizing Claude's native
+> description-matching and the workflow map in `.vine/context/shared.md`. Kept for design
+> provenance; archived in [PR #73](https://github.com/moduloMoments/VINE/pull/73).
+
 ### Problem Statement
 
 VINE commands have no structured relationship metadata — cross-references are implicit in prose. Claude Code already has two discovery mechanisms (ToolSearch for deferred tool loading, description-based skill matching), but VINE doesn't optimize for either. Command descriptions weren't written for Claude's ~250 char matching window. No routing context exists to help Claude suggest the right command at the right time.

--- a/.vine/projects/.archive/commands/tool-graph/SPEC.md
+++ b/.vine/projects/.archive/commands/tool-graph/SPEC.md
@@ -1,0 +1,132 @@
+# Feature Spec: Tool Graph
+## Date: 2026-04-06
+## Built on: CONTEXT.md (2026-04-06)
+## Decisions made by: Rob Bruhn
+
+### Problem Statement
+
+VINE commands have no structured relationship metadata — cross-references are implicit in prose. Claude Code already has two discovery mechanisms (ToolSearch for deferred tool loading, description-based skill matching), but VINE doesn't optimize for either. Command descriptions weren't written for Claude's ~250 char matching window. No routing context exists to help Claude suggest the right command at the right time.
+
+`vine:graph` audits and optimizes VINE's tool discovery layer. It adds structured relationship metadata, generates a routing-context artifact, and improves the descriptions that feed into Claude's built-in skill matching. No custom hooks, no runtime scripts — pure markdown, optimizing existing mechanisms.
+
+### Approach
+
+**Relationship frontmatter**: Extend all command files with a `relationships` field in YAML frontmatter. This is the authoritative source for tool relationships. Five relationship types:
+
+| Type | Meaning | Example |
+|------|---------|---------|
+| `consumes` | Reads another command's output artifact | inquire consumes verify's CONTEXT.md |
+| `produces-for` | Its output feeds another command | verify produces-for inquire |
+| `suggests` | Recommends running another command | evolve suggests vine:graph |
+| `switches-to` | Lateral context switch mid-session | verify switches-to pair |
+| `extends` | One command augments another's capability | init extends via vine:graph |
+
+Frontmatter format:
+```yaml
+relationships:
+  - target: vine:verify
+    type: consumes
+  - target: vine:navigate
+    type: produces-for
+```
+
+Unknown frontmatter fields are ignored by Claude Code — no impact on non-VINE users.
+
+**TOOL-GRAPH.md artifact**: Generated to `.vine/TOOL-GRAPH.md`. Contains tool inventory, Mermaid relationship diagram, and relationship table. Designed as routing context — shared.md references it so every VINE session has relationship awareness.
+
+**Description quality analysis**: vine:graph evaluates each command's `description` field against Claude's skill matching constraints (~250 chars, keyword density, action-verb clarity). Reports weak descriptions and offers to apply improvements with engineer approval.
+
+**Context injection via shared.md**: Rather than adding boilerplate to every command or building custom hooks, vine:graph updates shared.md to include a "Load Tool Graph" instruction. Since every command already loads shared.md, this gives every session graph-informed routing context through the existing hook system.
+
+### Key Decisions
+
+1. **Optimize existing mechanisms over building parallel systems** — Claude Code already has ToolSearch and description-based skill matching. vine:graph improves the data these mechanisms consume rather than building custom hook scripts or a separate discovery layer.
+2. **Relationship frontmatter over prose scanning** — One-time cost to update 13 files, but every future graph generation is deterministic and unambiguous. Prose scanning is noisy and interpretive.
+3. **`.vine/TOOL-GRAPH.md` location** — `.vine/` becomes the repo's tool intelligence layer. Teams track hooks + graph while gitignoring personal project state.
+4. **Report + offer to apply for descriptions** — vine:graph shows proposed description changes and asks permission before editing command files. Non-destructive by default.
+5. **Shared.md as the context injection point** — Every command already loads shared.md. Adding a TOOL-GRAPH.md reference there gives universal routing context without per-command boilerplate.
+6. **Workflows deferred** — Not an optimization of existing mechanisms. Deserves its own design cycle.
+7. **Auto-suggestion hooks deferred** — The "optimize descriptions + routing context" approach may be sufficient. If not, hooks build on this foundation in a follow-up cycle.
+
+### Acceptance Criteria
+
+1. `vine:graph` command exists in `commands/vine/graph.md` with valid YAML frontmatter (name, description, argument-hint, allowed-tools, relationships)
+2. All 13 existing command files (10 VINE + 3 contributor) have a `relationships` field in frontmatter with accurate type/target pairs using the five defined types
+3. Running `vine:graph` produces `.vine/TOOL-GRAPH.md` containing:
+   - Tool Inventory table (name, type, source, description, allowed-tools)
+   - Mermaid relationship diagram showing all declared relationships
+   - Relationship table (from, to, type, description)
+   - Generated-at metadata (date, repo path)
+4. vine:graph produces a description quality report evaluating each command's description against skill matching effectiveness
+5. vine:graph offers to apply improved descriptions with engineer approval (via AskUserQuestion)
+6. On repos without `.vine/`, vine:graph directs the user to run vine:init first
+7. `references/STATE.md` has a TOOL-GRAPH.md section with template, lifecycle, and design constraints
+8. `commands/vine/init.md` calls vine:graph as a step after hook setup
+9. `commands/vine/evolve.md` suggests running vine:graph after suggesting new commands/skills
+10. vine:graph updates `.vine/hooks/shared.md` to include a "Load Tool Graph" instruction referencing `.vine/TOOL-GRAPH.md`
+11. CLAUDE.md, README.md, `.vine/hooks/shared.md` updated to reflect 11 commands
+12. `/trellis` passes on all modified command files
+
+### Work Slices
+
+### Slice 1: Define TOOL-GRAPH.md format and relationship spec in STATE.md
+**Goal**: Establish the artifact contract and relationship type definitions before building the command
+**Depends on**: Nothing
+**Files likely touched**: `references/STATE.md`
+**Acceptance criteria**: STATE.md has a TOOL-GRAPH.md section with full template, relationship type definitions, lifecycle description, and design constraints. Uses `<!-- required -->` / `<!-- optional -->` markers on section headings.
+**Complexity signal**: Low — adding a section to an existing reference doc
+
+### Slice 2: Add relationship frontmatter to all commands
+**Goal**: Give every command structured relationship metadata
+**Depends on**: Slice 1 (relationship types defined in STATE.md)
+**Files likely touched**: All 13 files in `commands/vine/` and `.claude/commands/`
+**Acceptance criteria**: Each command has a `relationships` field with accurate type/target pairs using the five defined types (consumes, produces-for, suggests, switches-to, extends). Every command relates to at least one other. Relationships are bidirectional where applicable (if A produces-for B, B consumes A).
+**Complexity signal**: Medium — 13 files, need to map all relationships correctly across the full command graph
+
+### Slice 3: Build vine:graph core — discovery and TOOL-GRAPH.md generation
+**Goal**: The core command that discovers tools, parses frontmatter, and generates the graph artifact
+**Depends on**: Slice 1 (artifact format), Slice 2 (frontmatter to read)
+**Files likely touched**: `commands/vine/graph.md` (new file)
+**Acceptance criteria**: Command follows VINE structural conventions (frontmatter, hook loading, profile loading). Scans `.claude/commands/`, `.claude/skills/`, and settings files for MCP servers. Parses YAML frontmatter including relationships. Generates `.vine/TOOL-GRAPH.md` matching the STATE.md contract with all three sections (inventory, Mermaid diagram, relationship table). Handles non-VINE repos by directing to init. Works on this repo as a smoke test.
+**Complexity signal**: High — largest slice, core discovery and generation logic
+
+### Slice 4: Description quality analyzer
+**Goal**: Evaluate command descriptions against Claude's skill matching and offer improvements
+**Depends on**: Slice 3 (runs as part of vine:graph)
+**Files likely touched**: `commands/vine/graph.md` (extend with analysis section)
+**Acceptance criteria**: vine:graph evaluates each command's description for: length vs. ~250 char matching window, keyword density for intent matching, action-verb clarity, uniqueness across commands. Produces a quality report. Uses AskUserQuestion to offer applying improved descriptions — engineer approves each change individually. Does not edit files without approval.
+**Complexity signal**: Medium — analysis logic plus interactive approval flow
+
+### Slice 5: Integrate with init, evolve, and shared.md
+**Goal**: Wire vine:graph into the VINE lifecycle and enable routing context in every session
+**Depends on**: Slice 3 (command exists), Slice 4 (complete command)
+**Files likely touched**: `commands/vine/init.md`, `commands/vine/evolve.md`, `.vine/hooks/shared.md`
+**Acceptance criteria**: Init has a step that calls vine:graph after hook setup. Evolve suggests running vine:graph when it recommends new commands or skills. shared.md includes a "Load Tool Graph" section that instructs commands to read `.vine/TOOL-GRAPH.md` for routing context.
+**Complexity signal**: Low — adding steps to existing command prose and a section to shared.md
+
+### Slice 6: Documentation and checklist updates
+**Goal**: Update all tracking documents for the 11th command
+**Depends on**: Slices 3-5 (command and integrations finalized)
+**Files likely touched**: `CLAUDE.md`, `README.md`, `.vine/hooks/shared.md`
+**Acceptance criteria**: All references to command count say 11. vine:graph appears in command lists with accurate description. Command addition checklist from shared.md is fully satisfied. `/trellis` passes on all modified files.
+**Complexity signal**: Low — mechanical updates across known files
+
+### Tech Debt Integration
+
+- **Init's unstructured discovery** — Address during (Slice 5): graph gives init a structured source. Init's Step 1 can reference TOOL-GRAPH.md rather than doing its own ad-hoc scan.
+- **Help's hardcoded command list** — Defer: could reference TOOL-GRAPH.md later, but adding that dependency now complicates this cycle. Backlog item.
+- **Shared.md duplicates discoverable info** — Partially address (Slice 5): shared.md gains a reference to TOOL-GRAPH.md. The manually-maintained command list in shared.md remains for now but the graph provides the structured complement.
+
+### Dependencies & Risks
+
+- **Trellis validation**: Adding a `relationships` field to frontmatter may require trellis updates if it validates frontmatter strictly. Check trellis before Slice 2.
+- **Command count cascade**: The command addition checklist touches 4+ files. Missing one creates inconsistency. Slice 6 handles this systematically.
+- **Self-referential edge case**: vine:graph describes commands including itself. The relationships frontmatter in graph.md must accurately declare its own relationships without circular generation issues.
+- **Description changes need care**: Skill descriptions are the primary matching surface for Claude's auto-invocation. Improving them is high-value but wrong changes could break existing matching patterns. The report-and-approve flow mitigates this.
+
+### Backlog Updates
+
+- **Follow-up: Auto-suggestion hooks** — If optimized descriptions + routing context aren't sufficient for auto-suggestion, UserPromptSubmit hooks can be layered on top. The graph artifact is the data layer they'd query.
+- **Follow-up: Workflow templates** — Structured multi-step recipes. Not an optimization of existing mechanisms — needs its own design cycle.
+- **Follow-up: Context-aware vine:help** — Help reads TOOL-GRAPH.md + current project state to suggest commands based on where the user is in their workflow. Replaces hardcoded command list.
+- **Follow-up: Graph-informed evolve** — Evolve reads the graph to make more targeted suggestions about new skills, hook updates, and command improvements.


### PR DESCRIPTION
## Summary
Archives the `tool-graph` VINE project (working name `vine:graph`, 2026-04-06). It was specced through verify + inquire but never finished under that name — the idea evolved into and shipped as **`vine:optimize`** (#38, v0.3.0).

Moves the CONTEXT / SPEC / PROJECT-MAP artifacts from `.vine/projects/commands/tool-graph/` to `.vine/projects/.archive/commands/tool-graph/`, preserving the design provenance out of the active projects path. The files were previously untracked local state; this brings them into git as archived history.

## Notes
- `/trellis` artifact discovery already filters `.archive/`, so this has no effect on command/artifact validation.
- Independent of the cycle-3 archival work (#56) — this is a single superseded project that won't be backfilled (its outcome already shipped as optimize).

🤖 Generated with [Claude Code](https://claude.com/claude-code)