### PR TITLE
Roadmap: cycle-1 triage (polish cycle 1.5, 0.5 cleanup note, agent-issue closures)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,6 +30,7 @@ declining the migration must change nothing. The rename fallback in
 | # | Cycle | Issues | Mode | Why this order |
 |---|-------|--------|------|----------------|
 | 1 | **Platform alignment** | [#58](https://github.com/moduloMoments/VINE/issues/58) rename hooks→context, [#59](https://github.com/moduloMoments/VINE/issues/59) native hook enforcement, [#60](https://github.com/moduloMoments/VINE/issues/60) CLAUDE.md boundary, [#61](https://github.com/moduloMoments/VINE/issues/61) native task tracking, [#62](https://github.com/moduloMoments/VINE/issues/62) mode/gate/workflow hygiene | Full cycle | Changes vocabulary and structure every later cycle builds on. #58 lands first within the cycle. #62 was reshaped from "plan mode integration" to gearing↔permission-mode + inquire sign-off gate + artifact-commit guidance + between-slice `/clear` — plan mode is harness-owned, so VINE consumes it rather than integrating it (per the guiding principle). |
+| 1.5 | **Cycle-1 polish** | [#66](https://github.com/moduloMoments/VINE/issues/66) artifact-coherence checks, [#68](https://github.com/moduloMoments/VINE/issues/68) evolve CI-status read, [#69](https://github.com/moduloMoments/VINE/issues/69) navigate↔evolve verification reconciliation, [#70](https://github.com/moduloMoments/VINE/issues/70) runnable trellis check script | `vine:pair` (independent sessions) | Small follow-ups surfaced by cycle 1's evolve. Each is scoped + independent, so they run as standalone sessions/PRs rather than a batched cycle — no ordering dependency between them or on Cycle 2. #69 needs a design call on the navigate/evolve verification boundary; the other three are mechanical. |
 | 2 | **Maintenance batch** | [#46](https://github.com/moduloMoments/VINE/issues/46), [#47](https://github.com/moduloMoments/VINE/issues/47), [#48](https://github.com/moduloMoments/VINE/issues/48) consolidation; [#49](https://github.com/moduloMoments/VINE/issues/49), [#50](https://github.com/moduloMoments/VINE/issues/50) descriptions | `vine:pair` | Consolidation targets shared.md, so it lands *after* the rename to avoid double-touching. #49/#50 can go anytime. |
 | 3 | **Knowledge lifecycle** | [#51](https://github.com/moduloMoments/VINE/issues/51) durable knowledge layer, [#56](https://github.com/moduloMoments/VINE/issues/56) archival + backfill | Full cycle (multi-PR) | Promotion and archival share the SUMMARY/knowledge formats. Backfill quality depends on the knowledge format being settled, so they ship together. |
 | 4 | **Agent-native** | [#54](https://github.com/moduloMoments/VINE/issues/54) validation contract, [#53](https://github.com/moduloMoments/VINE/issues/53) headless autonomy contract | Full cycle | Headless agents need discoverable validation, so #54 precedes #53. Builds on native hooks (#59) and headless invocation patterns. |
@@ -39,16 +40,26 @@ declining the migration must change nothing. The rename fallback in
 ### Out of scope for v0.4.0
 
 Open issues not in the milestone ([#36](https://github.com/moduloMoments/VINE/issues/36) vine:grow,
-[#39](https://github.com/moduloMoments/VINE/issues/39) integration-checker,
-[#40](https://github.com/moduloMoments/VINE/issues/40) design-checker,
 [#42](https://github.com/moduloMoments/VINE/issues/42) debugger agent,
 [#43](https://github.com/moduloMoments/VINE/issues/43) UI audit) are deferred — they add agents and
 phases, and the platform-alignment principle says to revisit them after v0.4.0 to see how much the
 native tooling already covers.
 
+Closed during cycle-1 triage as already-covered: #39 integration-checker (the existing
+`vine-verification` agent's feature mode does cross-slice integration — proven in cycle 1's evolve)
+and #40 design-checker (the inquire sign-off gate is VINE's chosen design-validation mechanism; an
+automated checker is the performative-findings pattern #66 rejects).
+
 Also deliberately deferred: parallel slice execution (premature until the headless contract in
 [#53](https://github.com/moduloMoments/VINE/issues/53) exists), HTML output, and org-level agents
 (risk auditors, summary agents) — those live a layer above a per-repo framework.
+
+### Post-0.4.0 cleanup
+
+[#64](https://github.com/moduloMoments/VINE/issues/64) removes the `.vine/hooks/` legacy fallback.
+It is **gated on the 0.5 release**, not schedulable within v0.4.0 — the fallback must ship through
+all of 0.4.x (the one-minor-version compatibility window from #58), then the removal + trellis
+Check 9 hardening land together at 0.5.
 
 ### Process notes
 

--- a/commands/vine/evolve.md
+++ b/commands/vine/evolve.md
@@ -86,6 +86,25 @@ validation status).
 Present a rollup of per-slice results from NAVIGATION.md, then focus your effort on what
 navigate couldn't verify:
 
+### Acceptance Criteria Traceability
+
+SPEC.md's top-level `### Acceptance Criteria` is the cycle's contract — distinct from the
+per-slice checklists navigate verified. Nothing else confirms every cycle-level criterion
+actually landed in a slice, so build a two-column mapping of each criterion to its evidence:
+
+| Acceptance criterion (SPEC) | Evidence (slice / commit) |
+|---|---|
+| [criterion text] | Slice N — [commit hash] |
+| [criterion text] | **unaccounted** |
+
+Pull the evidence from NAVIGATION.md's slice entries (their per-slice acceptance criteria and
+commit hashes). This is a lookup against the record, not a re-verification — trust the
+per-slice validation. A criterion with no slice/commit behind it is **unaccounted**: surface
+it rather than letting it silently vanish. Unaccounted usually means one of two things — a
+slice covered it without recording the link (fixable: note the evidence) or the cycle didn't
+deliver it (a real gap for the engineer to decide on before shipping). This table is the
+Acceptance Criteria Results in EVOLUTION.md.
+
 ### Cross-Slice Integration Check
 
 This is where evolve adds value. Delegate to the `vine-verification` agent in feature verification
@@ -107,9 +126,13 @@ mode, passing it these checks to perform:
 - Run `gh pr view <number>` for each shipped phase's PR to check status and review comments
 - Run `gh api repos/{owner}/{repo}/pulls/<number>/comments` to surface reviewer feedback
   that may affect the current phase
+- Run `gh pr checks <number>` for each shipped phase's PR to read CI status — a framework
+  that preps the handoff shouldn't be blind to red checks
 - Flag any unresolved review comments or requested changes from prior PRs — these could
   indicate integration issues or concerns that carry forward
-- Include a summary of cross-PR review findings in the Product Evolution section
+- Flag any failing or still-pending checks from prior PRs — surface them in the Product
+  Evolution section so they're visible before the handoff
+- Include a summary of cross-PR review findings and CI status in the Product Evolution section
 
 ### Review Spec Deviations
 
@@ -473,7 +496,10 @@ Present the commit message for the engineer's approval before committing.
 
 ### Suggest Opening a PR
 
-After committing, suggest opening a PR using the handoff package drafted earlier:
+After committing, suggest opening a PR using the handoff package drafted earlier. First, if
+the cross-slice integration check captured CI status from prior phase PRs (`gh pr checks`),
+restate any failing or still-pending checks here — don't suggest a handoff over red or
+in-flight CI without the engineer seeing it. No-op if `gh` was unavailable or all checks passed.
 
 > "Ready to open a PR? I have the description and reviewer notes drafted in EVOLUTION.md."
 

--- a/commands/vine/navigate.md
+++ b/commands/vine/navigate.md
@@ -517,17 +517,25 @@ Read NAVIGATION.md and verify each slice entry has:
 - **Validation status**: Filled in (pass or fail with resolution)
 - **Acceptance criteria**: At least one criterion checked (either `[x]` or `[ ]` with reason)
 - **Learnings**: Not empty — at minimum "None" is acceptable, but blank is not
+- **Deviation closure**: For every slice whose "Deviations from spec" is not "None" (or
+  blank), confirm SPEC.md carries the matching annotation step 6 requires — a strikethrough
+  or addendum in the affected section. This is a lookup, not a judgment call: like a missing
+  commit hash, a recorded deviation with no SPEC.md annotation is a gap. Grep SPEC.md for the
+  deviation's subject if you're unsure it's there. The point is to never leave evolve
+  cross-referencing two documents to reconstruct what changed.
 
 If any slice has gaps, list them:
 
 > "Before we wrap up, NAVIGATION.md has some gaps:
 > - Slice 2: missing learnings
+> - Slice 3: deviation recorded ('switched to async init') but SPEC.md has no annotation for it
 > - Slice 4: commit hash still says 'pending'
 > Want me to fill these in now?"
 
 Fix the gaps inline — update NAVIGATION.md with the engineer's input (or fill in what you
-can from the commit history and conversation context). Don't proceed to the completion block
-until the gate passes.
+can from the commit history and conversation context). For an unclosed deviation, the fix is
+to add the missing SPEC.md annotation (step 6), not to edit NAVIGATION.md. Don't proceed to
+the completion block until the gate passes.
 
 ### Remaining Work
 

--- a/references/STATE.md
+++ b/references/STATE.md
@@ -138,6 +138,10 @@ The implementation journal. Built incrementally — each slice is appended as it
 
 **Remaining Work dependency.** The `### Remaining Work` section stays `<!-- optional -->` because it only exists at session boundaries — `vine:navigate` writes it when pausing between slices and at phase completion, so a mid-implementation journal legitimately won't have it (promoting it to required would fail validation on every in-progress journal). When it *is* present, two readers depend on it: `vine:resume`'s no-PAUSE.md path reconstructs handoff state from it, and native-task rebuild (see [Source of Truth vs Derived Views](#source-of-truth-vs-derived-views)) uses it for cross-slice context.
 
+**Deviation-closure contract.** When a slice's `**Deviations from spec**` field is anything but "None", `vine:navigate` step 6 also annotates the affected SPEC.md section (strikethrough/addendum), and navigate's completion gate verifies the pair held — an annotated-nowhere deviation is a gate gap, listed like a missing commit hash. The rule is load-bearing and lives in the command (this file is supplementary and doesn't ship via create-vine); it's recorded here so contributors editing the field keep both halves in sync.
+
+**AC-traceability contract.** SPEC.md's top-level `### Acceptance Criteria` is the cycle contract, distinct from the per-slice `**Acceptance criteria**` checklists. `vine:evolve`'s verification rollup maps each cycle-level criterion to the slice/commit that satisfied it, flagging any with no evidence as **unaccounted** — this mapping is the EVOLUTION.md *Acceptance Criteria Results* table. As above, the rule lives in the command; this note keeps the two AC layers legible to contributors.
+
 ### EVOLUTION.md (produced by vine:evolve)
 
 The triple evolution report. Captures growth across product, agent, and user.


### PR DESCRIPTION
## Summary
Post-cycle-1 backlog triage. Updates ROADMAP.md to reflect the issues spawned during the platform-alignment cycle and prune two now-covered agent ideas.

## Changes
- **New cycle row 1.5 — Cycle-1 polish**: #66 (artifact-coherence checks), #68 (evolve CI-status read), #69 (navigate↔evolve verification reconciliation), #70 (runnable trellis script). Scoped + independent, so they run as standalone `vine:pair` sessions/PRs rather than a batched cycle. All four assigned to the v0.4.0 milestone. #66/#68/#70 already in flight as independent worktree sessions.
- **Post-0.4.0 cleanup section**: #64 (`.vine/hooks/` fallback removal) documented as gated on the 0.5 release — it can't be scheduled within v0.4.0 because the fallback must ship through all of 0.4.x.
- **Out-of-scope updated**: removed #39 and #40 (closed this triage), kept #36/#42/#43 deferred.

## Closed alongside this (already covered, not in diff)
- **#39 integration-checker** — superseded by `vine-verification` feature mode (proved 8/8 cross-slice contracts in cycle 1's evolve).
- **#40 design-checker** — the inquire sign-off gate (Slice 18) is VINE's design-validation mechanism; an automated checker is the performative-findings pattern #66 rejects.
- **#71 h4→h3 normalization** — closed as won't-do (marginal; all repo h4 specs already resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)