### PR TITLE
evolve: read prior-PR CI status (gh pr checks) before suggesting a PR

### DIFF
--- a/commands/vine/evolve.md
+++ b/commands/vine/evolve.md
@@ -107,9 +107,13 @@ mode, passing it these checks to perform:
 - Run `gh pr view <number>` for each shipped phase's PR to check status and review comments
 - Run `gh api repos/{owner}/{repo}/pulls/<number>/comments` to surface reviewer feedback
   that may affect the current phase
+- Run `gh pr checks <number>` for each shipped phase's PR to read CI status — a framework
+  that preps the handoff shouldn't be blind to red checks
 - Flag any unresolved review comments or requested changes from prior PRs — these could
   indicate integration issues or concerns that carry forward
-- Include a summary of cross-PR review findings in the Product Evolution section
+- Flag any failing or still-pending checks from prior PRs — surface them in the Product
+  Evolution section so they're visible before the handoff
+- Include a summary of cross-PR review findings and CI status in the Product Evolution section
 
 ### Review Spec Deviations
 
@@ -473,7 +477,10 @@ Present the commit message for the engineer's approval before committing.
 
 ### Suggest Opening a PR
 
-After committing, suggest opening a PR using the handoff package drafted earlier:
+After committing, suggest opening a PR using the handoff package drafted earlier. First, if
+the cross-slice integration check captured CI status from prior phase PRs (`gh pr checks`),
+restate any failing or still-pending checks here — don't suggest a handoff over red or
+in-flight CI without the engineer seeing it. No-op if `gh` was unavailable or all checks passed.
 
 > "Ready to open a PR? I have the description and reviewer notes drafted in EVOLUTION.md."
 


### PR DESCRIPTION
## What

Adds a `gh pr checks <number>` read to `vine:evolve`'s multi-PR integration block. During the Cross-Slice Integration Check, evolve already runs `gh pr view` and fetches review comments for each shipped phase's PR; this teaches it to also read CI status. Failing/pending checks are surfaced in the Product Evolution section and restated before the "Suggest Opening a PR" step.

## Why

`vine:evolve` preps the PR handoff but was blind to whether prior phase PRs' CI was green — it could suggest a handoff while checks were red and never surface it. For a framework whose job includes "is this ready to ship," CI visibility is a natural part of the integration check.

The new read is gated on `gh` availability exactly like the existing PR-review step, and no-ops when `gh` is absent or all checks pass.

Closes #68

## How to test

Run `/vine:evolve` on a multi-PR feature (one whose PROJECT-MAP.md has a Milestones table with PR numbers) in a repo with `gh` available. Confirm evolve runs `gh pr checks <number>` for each shipped PR, reports failing/pending checks in the Product Evolution section, and restates them before suggesting the PR. With `gh` unavailable, confirm the step no-ops.

## Checklist

- [ ] I've tested this in an actual VINE cycle (if changing command behavior) — not run end-to-end; this is a prose-only edit to the evolve.md command file, validated structurally with `/trellis` (11/11 commands pass)
- [x] Changes are focused on a single concern
- [x] Any new behavior is documented in the README or command file

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)