### PR TITLE
Targeted artifact-coherence checks: deviation closure + AC traceability (#66)

### DIFF
--- a/commands/vine/evolve.md
+++ b/commands/vine/evolve.md
@@ -86,6 +86,25 @@ validation status).
 Present a rollup of per-slice results from NAVIGATION.md, then focus your effort on what
 navigate couldn't verify:
 
+### Acceptance Criteria Traceability
+
+SPEC.md's top-level `### Acceptance Criteria` is the cycle's contract — distinct from the
+per-slice checklists navigate verified. Nothing else confirms every cycle-level criterion
+actually landed in a slice, so build a two-column mapping of each criterion to its evidence:
+
+| Acceptance criterion (SPEC) | Evidence (slice / commit) |
+|---|---|
+| [criterion text] | Slice N — [commit hash] |
+| [criterion text] | **unaccounted** |
+
+Pull the evidence from NAVIGATION.md's slice entries (their per-slice acceptance criteria and
+commit hashes). This is a lookup against the record, not a re-verification — trust the
+per-slice validation. A criterion with no slice/commit behind it is **unaccounted**: surface
+it rather than letting it silently vanish. Unaccounted usually means one of two things — a
+slice covered it without recording the link (fixable: note the evidence) or the cycle didn't
+deliver it (a real gap for the engineer to decide on before shipping). This table is the
+Acceptance Criteria Results in EVOLUTION.md.
+
 ### Cross-Slice Integration Check
 
 This is where evolve adds value. Delegate to the `vine-verification` agent in feature verification

--- a/commands/vine/navigate.md
+++ b/commands/vine/navigate.md
@@ -517,17 +517,25 @@ Read NAVIGATION.md and verify each slice entry has:
 - **Validation status**: Filled in (pass or fail with resolution)
 - **Acceptance criteria**: At least one criterion checked (either `[x]` or `[ ]` with reason)
 - **Learnings**: Not empty — at minimum "None" is acceptable, but blank is not
+- **Deviation closure**: For every slice whose "Deviations from spec" is not "None" (or
+  blank), confirm SPEC.md carries the matching annotation step 6 requires — a strikethrough
+  or addendum in the affected section. This is a lookup, not a judgment call: like a missing
+  commit hash, a recorded deviation with no SPEC.md annotation is a gap. Grep SPEC.md for the
+  deviation's subject if you're unsure it's there. The point is to never leave evolve
+  cross-referencing two documents to reconstruct what changed.
 
 If any slice has gaps, list them:
 
 > "Before we wrap up, NAVIGATION.md has some gaps:
 > - Slice 2: missing learnings
+> - Slice 3: deviation recorded ('switched to async init') but SPEC.md has no annotation for it
 > - Slice 4: commit hash still says 'pending'
 > Want me to fill these in now?"
 
 Fix the gaps inline — update NAVIGATION.md with the engineer's input (or fill in what you
-can from the commit history and conversation context). Don't proceed to the completion block
-until the gate passes.
+can from the commit history and conversation context). For an unclosed deviation, the fix is
+to add the missing SPEC.md annotation (step 6), not to edit NAVIGATION.md. Don't proceed to
+the completion block until the gate passes.
 
 ### Remaining Work
 

--- a/references/STATE.md
+++ b/references/STATE.md
@@ -138,6 +138,10 @@ The implementation journal. Built incrementally — each slice is appended as it
 
 **Remaining Work dependency.** The `### Remaining Work` section stays `<!-- optional -->` because it only exists at session boundaries — `vine:navigate` writes it when pausing between slices and at phase completion, so a mid-implementation journal legitimately won't have it (promoting it to required would fail validation on every in-progress journal). When it *is* present, two readers depend on it: `vine:resume`'s no-PAUSE.md path reconstructs handoff state from it, and native-task rebuild (see [Source of Truth vs Derived Views](#source-of-truth-vs-derived-views)) uses it for cross-slice context.
 
+**Deviation-closure contract.** When a slice's `**Deviations from spec**` field is anything but "None", `vine:navigate` step 6 also annotates the affected SPEC.md section (strikethrough/addendum), and navigate's completion gate verifies the pair held — an annotated-nowhere deviation is a gate gap, listed like a missing commit hash. The rule is load-bearing and lives in the command (this file is supplementary and doesn't ship via create-vine); it's recorded here so contributors editing the field keep both halves in sync.
+
+**AC-traceability contract.** SPEC.md's top-level `### Acceptance Criteria` is the cycle contract, distinct from the per-slice `**Acceptance criteria**` checklists. `vine:evolve`'s verification rollup maps each cycle-level criterion to the slice/commit that satisfied it, flagging any with no evidence as **unaccounted** — this mapping is the EVOLUTION.md *Acceptance Criteria Results* table. As above, the rule lives in the command; this note keeps the two AC layers legible to contributors.
+
 ### EVOLUTION.md (produced by vine:evolve)
 
 The triple evolution report. Captures growth across product, agent, and user.


### PR DESCRIPTION
## What

Adds two targeted artifact-coherence checks at existing VINE checkpoints, both with mechanical pass/fail teeth:

1. **Deviation closure** — `vine:navigate`'s completion gate now verifies that every slice whose `**Deviations from spec**` is not "None" carries the matching SPEC.md annotation (strikethrough/addendum) that step 6 requires. It's a lookup, listed alongside missing commit hashes; the fix is to add the SPEC annotation, not edit NAVIGATION.md.
2. **AC traceability** — `vine:evolve`'s verification rollup gains an *Acceptance Criteria Traceability* subsection that maps each cycle-level SPEC acceptance criterion to its slice/commit evidence, or flags it **unaccounted**. This becomes the EVOLUTION.md *Acceptance Criteria Results* table.

`references/STATE.md` gets two compact contract notes tying the NAVIGATION deviation field and the SPEC cycle-level ACs to the commands that read them. The load-bearing rules live in the command files (STATE.md is supplementary and does not ship via create-vine).

## Why

Cross-artifact coherence (CONTEXT → SPEC → NAVIGATION → EVOLUTION) was maintained by discipline, not verification. A recorded deviation with no SPEC annotation, or a cycle-level criterion that never mapped to a slice, would stay silent until evolve was back to cross-referencing two documents — the exact failure these checkpoints exist to prevent.

Per the issue, a general agent "cohesion check" was **explicitly rejected** (vague verdicts, performative findings). These two checks are deliberately narrow lookups with observable teeth instead.

Closes #66

## How to test

- Run `/trellis` — 11/11 commands pass (validated; no structural drift from the prose edits).
- In a `vine:navigate` completion gate, a slice recording a deviation with no SPEC.md annotation is now listed as a gap like a missing commit hash.
- In `vine:evolve` Evolution 1, cycle-level SPEC acceptance criteria are presented as a criterion → slice/commit table, with unmapped criteria flagged **unaccounted**.

## Checklist

- [x] Changes are focused on a single concern
- [x] Any new behavior is documented in the command files (and STATE.md contributor contract)
- [ ] I've tested this in an actual VINE cycle (prose-only edits; validated via /trellis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)