### PR TITLE
Add trellis-check.sh: scriptable command checks for a reproducible stamp

### DIFF
--- a/.vine/scripts/run-tests.sh
+++ b/.vine/scripts/run-tests.sh
@@ -83,5 +83,86 @@ check "trellis-gate: non-commit -> allow" 0 $?
 
 rm -rf "$T"
 
+# ---------- trellis-check.sh ----------
+C="$SCRIPTS_DIR/trellis-check.sh"
+
+# Writes a minimal command file that passes every command check. Args:
+#   mkcmd <dir> <stem> <name-field> <h1-stem> <extra-overlay-line>
+mkcmd() {
+  cat > "$1/commands/vine/$2.md" <<EOF
+---
+name: $3
+description: "d"
+argument-hint: ""
+allowed-tools:
+  - Read
+  - AskUserQuestion
+---
+
+# vine:$4 — Sub
+
+## Load Context Overlays
+
+Read \`.vine/context/$2.md\` if it exists.
+$5
+
+## Load Engineer Profile
+
+Read the profile. Decisions use AskUserQuestion.
+EOF
+}
+
+T=$(mktemp -d)
+mkdir -p "$T/commands/vine" "$T/.vine"
+export CLAUDE_PROJECT_DIR="$T"
+
+mkcmd "$T" good "vine:good" good ""
+sh "$C" >/dev/null 2>&1
+check "trellis-check: all valid -> pass (exit 0)" 0 $?
+grep -q '^status: pass' "$T/.vine/.trellis-ok"
+check "trellis-check: pass writes 'status: pass' stamp" 0 $?
+
+mkcmd "$T" bad "vine:WRONG" bad ""
+sh "$C" >/dev/null 2>&1
+check "trellis-check: name mismatch -> fail (exit 1)" 1 $?
+grep -q '^status: fail' "$T/.vine/.trellis-ok"
+check "trellis-check: fail overwrites stamp with 'status: fail'" 0 $?
+rm "$T/commands/vine/bad.md"
+
+# init/help skip the overlays/profile/order checks — a stub with neither passes.
+cat > "$T/commands/vine/init.md" <<'EOF'
+---
+name: vine:init
+description: "d"
+argument-hint: ""
+allowed-tools:
+  - Read
+  - AskUserQuestion
+---
+
+# vine:init — Setup
+
+Body uses AskUserQuestion. No overlays/profile sections, by design.
+EOF
+sh "$C" >/dev/null 2>&1
+check "trellis-check: init skips overlays/profile/order -> pass" 0 $?
+rm "$T/commands/vine/init.md"
+
+# Stray legacy .vine/hooks ref outside the allowlist -> warning only, still pass.
+mkcmd "$T" leg "vine:leg" leg 'Stray ref: `.vine/hooks/leg.md`.'
+warnout=$(sh "$C" 2>/dev/null)
+check "trellis-check: stray legacy ref stays a warning -> pass" 0 $?
+printf '%s' "$warnout" | grep -q 'leg.md:.*\.vine/hooks'
+check "trellis-check: stray legacy ref is reported as a warning" 0 $?
+rm "$T/commands/vine/leg.md"
+
+# The allowlisted fallback paragraph must NOT warn.
+mkcmd "$T" fb "vine:fb" fb "If \`.vine/context/\` doesn't exist but legacy \`.vine/hooks/\` does, read from \`.vine/hooks/\` instead."
+warnout=$(sh "$C" 2>/dev/null)
+printf '%s' "$warnout" | grep -q 'fb.md:.*\.vine/hooks'
+check "trellis-check: allowlisted fallback paragraph does not warn" 1 $?
+
+rm -rf "$T"
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.vine/scripts/trellis-check.sh
+++ b/.vine/scripts/trellis-check.sh
@@ -1,0 +1,272 @@
+#!/bin/sh
+# VINE trellis command-check engine (contributor-only — NOT part of the user
+# scaffold; create-vine never copies this script).
+#
+# Runs trellis's command checks (Steps 1-4 of .claude/commands/trellis.md)
+# mechanically, so the .vine/.trellis-ok stamp the gate reads becomes
+# deterministic and CI-runnable instead of session-interpreted. The harder
+# artifact checks (Steps 5-7, STATE.md template parsing) stay in the skill —
+# they are out of scope here.
+#
+# Checks implemented, per command file in commands/vine/:
+#   1 Frontmatter present with exactly name/description/argument-hint/allowed-tools
+#   2 name == vine:<stem>
+#   3 H1 == "# vine:<stem> — <subtitle>" (with the ` — ` em-dash separator)
+#   4 Load Context Overlays section names .vine/context/<stem>.md (skip init/help)
+#   5 Load Engineer Profile section present (skip init/help)
+#   6 Overlays heading precedes Profile heading (skip init/help)
+#   7 allowed-tools well-formed (single capitalized words) and known (union)
+#   8 AskUserQuestion referenced in the body
+#   9 Legacy .vine/hooks references outside the two allowlisted spots -> WARNING
+#
+# Writes .vine/.trellis-ok in the format the gate expects: a "status: pass"
+# (or "status: fail") first line. Warnings never change pass/fail (matches the
+# skill: legacy refs are warnings only). Exit 0 = all command checks pass,
+# exit 1 = at least one failure. POSIX sh only — no bashisms, no jq.
+#
+# Usage: sh .vine/scripts/trellis-check.sh
+
+set -u
+
+root="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+CMD_DIR="$root/commands/vine"
+STAMP="$root/.vine/.trellis-ok"
+
+EXPECTED_FIELDS="allowed-tools argument-hint description name"
+
+if [ ! -d "$CMD_DIR" ]; then
+  echo "trellis-check: no commands/vine/ directory at $root — nothing to validate." >&2
+  exit 1
+fi
+
+# ---------- frontmatter helpers ----------
+
+# Top-level frontmatter keys (between line 1's --- and the closing ---).
+fm_fields() {
+  awk 'NR==1{next} /^---$/{exit} /^[A-Za-z][A-Za-z-]*:/{sub(/:.*/,""); print}' "$1"
+}
+
+# allowed-tools list entries (the only multi-line list in the frontmatter).
+fm_tools() {
+  awk 'NR==1{next} /^---$/{exit} /^[[:space:]]*-[[:space:]]/{
+    sub(/^[[:space:]]*-[[:space:]]*/,""); sub(/[[:space:]]+$/,""); print
+  }' "$1"
+}
+
+# First H1 line after the frontmatter.
+h1_line() {
+  awk '/^---$/{c++; next} c>=2 && /^# /{print; exit}' "$1"
+}
+
+# Body (everything after the closing ---).
+body_has_askuser() {
+  awk '/^---$/{c++; next} c>=2' "$1" | grep -q 'AskUserQuestion'
+}
+
+# ---------- Step 2: build the union tool set ----------
+
+UNION=$(for f in "$CMD_DIR"/*.md; do fm_tools "$f"; done | sort -u)
+
+is_known_tool() {
+  printf '%s\n' "$UNION" | grep -qx "$1"
+}
+
+# ---------- per-command validation ----------
+
+PASS_CMDS=0
+ISSUE_COUNT=0
+FAIL_CMDS=0
+FAILDETAIL=""
+WARNINGS=""
+
+cell() { # cell <ok 0|1> ; echos a fixed-width status glyph
+  if [ "$1" -eq 0 ]; then printf '%-5s' '✅'; else printf '%-5s' '❌'; fi
+}
+skipcell() { printf '%-5s' 'skip'; }
+
+note_fail() { # note_fail <stem> <check> <detail>
+  ISSUE_COUNT=$((ISSUE_COUNT + 1))
+  FAILDETAIL="$FAILDETAIL
+  - $1 — $2: $3"
+}
+
+printf '| %-9s | %-5s | %-5s | %-5s | %-5s | %-5s | %-5s | %-5s | %-5s |\n' \
+  Command Front Name H1 Overlay Profile Order Tools AskUsr
+printf '|%s|%s|%s|%s|%s|%s|%s|%s|%s|\n' \
+  '-----------' '-------' '-------' '-------' '-------' '-------' '-------' '-------' '-------'
+
+for f in "$CMD_DIR"/*.md; do
+  stem=$(basename "$f" .md)
+  cmd_failed=0
+
+  case "$stem" in
+    init|help) skip_overlay=1 ;;
+    *) skip_overlay=0 ;;
+  esac
+
+  # --- Check 1: frontmatter, exactly the 4 fields ---
+  first=$(awk 'NR==1{print; exit}' "$f")
+  fm_end=$(awk 'NR>1 && /^---$/{print NR; exit}' "$f")
+  c1=1
+  if [ "$first" = "---" ] && [ -n "$fm_end" ]; then
+    got=$(fm_fields "$f" | sort -u | tr '\n' ' ' | sed 's/ *$//')
+    want=$(printf '%s' "$EXPECTED_FIELDS" | tr ' ' '\n' | sort -u | tr '\n' ' ' | sed 's/ *$//')
+    [ "$got" = "$want" ] && c1=0
+  fi
+  if [ "$c1" -ne 0 ]; then
+    note_fail "$stem" Frontmatter "expected exactly [$EXPECTED_FIELDS]"
+    cmd_failed=1
+  fi
+
+  # --- Check 2: name == vine:<stem> ---
+  name=$(awk 'NR==1{next} /^---$/{exit} /^name:/{sub(/^name:[[:space:]]*/,""); gsub(/["'\'']/,""); sub(/[[:space:]]+$/,""); print; exit}' "$f")
+  c2=1
+  [ "$name" = "vine:$stem" ] && c2=0
+  if [ "$c2" -ne 0 ]; then
+    note_fail "$stem" Name "name is '$name', expected 'vine:$stem'"
+    cmd_failed=1
+  fi
+
+  # --- Check 3: H1 format "# vine:<stem> — <subtitle>" ---
+  h1=$(h1_line "$f")
+  c3=1
+  case "$h1" in
+    "# vine:$stem — "*) c3=0 ;;
+  esac
+  if [ "$c3" -ne 0 ]; then
+    note_fail "$stem" H1 "H1 is '$h1', expected '# vine:$stem — <subtitle>'"
+    cmd_failed=1
+  fi
+
+  # --- Checks 4/5/6: overlays + profile (skip init/help) ---
+  if [ "$skip_overlay" -eq 1 ]; then
+    c4=skip; c5=skip; c6=skip
+  else
+    ov=$(grep -n '^## Load Context Overlays' "$f" | head -1 | cut -d: -f1)
+    pr=$(grep -n '^## Load Engineer Profile' "$f" | head -1 | cut -d: -f1)
+
+    # Check 4: phase path present in the overlays section.
+    c4=1
+    if [ -n "$ov" ]; then
+      sect=$(awk -v s="$ov" 'NR>s && /^## /{exit} NR>=s{print}' "$f")
+      printf '%s\n' "$sect" | grep -q "\.vine/context/$stem\.md" && c4=0
+    fi
+    if [ "$c4" -ne 0 ]; then
+      note_fail "$stem" Overlays "overlays section missing .vine/context/$stem.md"
+      cmd_failed=1
+    fi
+
+    # Check 5: profile section present.
+    c5=1
+    [ -n "$pr" ] && c5=0
+    if [ "$c5" -ne 0 ]; then
+      note_fail "$stem" Profile "missing '## Load Engineer Profile' heading"
+      cmd_failed=1
+    fi
+
+    # Check 6: overlays before profile.
+    c6=1
+    if [ -n "$ov" ] && [ -n "$pr" ] && [ "$ov" -lt "$pr" ]; then c6=0; fi
+    if [ "$c6" -ne 0 ]; then
+      note_fail "$stem" Order "Load Context Overlays must precede Load Engineer Profile"
+      cmd_failed=1
+    fi
+  fi
+
+  # --- Check 7: allowed-tools well-formed + known ---
+  c7=0
+  tools=$(fm_tools "$f")
+  if [ -z "$tools" ]; then
+    c7=1
+    note_fail "$stem" Tools "allowed-tools is empty"
+  else
+    for t in $tools; do
+      case "$t" in
+        *[!A-Za-z]*|"")
+          c7=1; note_fail "$stem" Tools "malformed tool entry '$t'"; continue ;;
+      esac
+      case "$t" in
+        [A-Z]*) ;;
+        *) c7=1; note_fail "$stem" Tools "tool '$t' not capitalized"; continue ;;
+      esac
+      if ! is_known_tool "$t"; then
+        c7=1; note_fail "$stem" Tools "unknown tool '$t' (not in union)"
+      fi
+    done
+  fi
+  [ "$c7" -ne 0 ] && cmd_failed=1
+
+  # --- Check 8: AskUserQuestion referenced in body ---
+  c8=1
+  body_has_askuser "$f" && c8=0
+  if [ "$c8" -ne 0 ]; then
+    note_fail "$stem" AskUser "AskUserQuestion not referenced in body"
+    cmd_failed=1
+  fi
+
+  # --- Check 9: legacy .vine/hooks references (warning-only) ---
+  # Allowlist: the fallback paragraph (loading commands) and init.md's
+  # "### Legacy Directory Migration" section. Anything else warns.
+  warn=$(awk '
+    {
+      line=$0
+      if (line ~ /^### Legacy Directory Migration/) mig=1
+      else if (mig && line ~ /^#{1,3} /) mig=0
+      if (line ~ /^If `\.vine\/context\/` doesn.t exist but legacy `\.vine\/hooks\/` does/) para=1
+      else if (para && line ~ /^$/) para=0
+      if (line ~ /\.vine\/hooks/ && !(mig || para)) printf "%d\t%s\n", NR, line
+    }' "$f")
+  if [ -n "$warn" ]; then
+    while IFS=$(printf '\t') read -r ln txt; do
+      [ -n "$ln" ] || continue
+      WARNINGS="$WARNINGS
+- $stem.md:$ln — $txt"
+    done <<EOF
+$warn
+EOF
+  fi
+
+  # --- render row ---
+  if [ "$c4" = skip ]; then ov_c=$(skipcell); pr_c=$(skipcell); or_c=$(skipcell)
+  else ov_c=$(cell "$c4"); pr_c=$(cell "$c5"); or_c=$(cell "$c6"); fi
+  printf '| %-9s | %s| %s| %s| %s| %s| %s| %s| %s|\n' \
+    "$stem" "$(cell "$c1")" "$(cell "$c2")" "$(cell "$c3")" \
+    "$ov_c" "$pr_c" "$or_c" "$(cell "$c7")" "$(cell "$c8")"
+
+  if [ "$cmd_failed" -eq 0 ]; then
+    PASS_CMDS=$((PASS_CMDS + 1))
+  else
+    FAIL_CMDS=$((FAIL_CMDS + 1))
+  fi
+done
+
+TOTAL=$((PASS_CMDS + FAIL_CMDS))
+
+echo
+if [ "$ISSUE_COUNT" -eq 0 ]; then
+  SUMMARY="✅ $TOTAL/$TOTAL commands pass all checks"
+  STATUS="pass"
+else
+  SUMMARY="❌ $ISSUE_COUNT issues found across $FAIL_CMDS commands"
+  STATUS="fail"
+fi
+echo "$SUMMARY"
+[ -n "$FAILDETAIL" ] && printf '%s\n' "$FAILDETAIL"
+
+if [ -n "$WARNINGS" ]; then
+  echo
+  echo "⚠️ Legacy \`.vine/hooks/\` references (warnings — slated to harden to failures"
+  echo "   with the 0.5 fallback removal):"
+  printf '%s\n' "$WARNINGS"
+fi
+
+# ---------- Step 8: write the pass stamp ----------
+when=$(date '+%Y-%m-%d %H:%M' 2>/dev/null || echo unknown)
+mkdir -p "$root/.vine"
+{
+  echo "status: $STATUS"
+  echo "checked: $when"
+  echo "summary: $SUMMARY"
+} > "$STAMP"
+
+[ "$STATUS" = pass ]


### PR DESCRIPTION
Closes #70.

## What

Adds `.vine/scripts/trellis-check.sh` — a POSIX-sh engine that runs trellis's **command checks (Steps 1–4)** mechanically, so the `.vine/.trellis-ok` stamp the gate reads becomes deterministic and CI-runnable instead of session-interpreted.

Per command file in `commands/vine/`, it runs all nine command checks:

1. Frontmatter present with exactly `name` / `description` / `argument-hint` / `allowed-tools`
2. `name` == `vine:<stem>`
3. H1 == `# vine:<stem> — <subtitle>` (the ` — ` em-dash separator)
4. Load Context Overlays section names `.vine/context/<stem>.md` (skip init/help)
5. Load Engineer Profile section present (skip init/help)
6. Overlays heading precedes Profile heading (skip init/help)
7. `allowed-tools` well-formed (single capitalized words) and known against the union set
8. `AskUserQuestion` referenced in the body
9. Legacy `.vine/hooks` references outside the two allowlisted spots → **warning** (the fallback paragraph and init.md's `### Legacy Directory Migration` section)

It writes the same `status: pass|fail` stamp format `trellis-gate.sh` expects. Warnings never change pass/fail (matches the skill). Exit 0 = green, 1 = failure.

## Out of scope

The harder artifact checks (Steps 5–7, STATE.md template parsing) stay in the `/trellis` skill — the skill remains the authoring/UX surface; this script is the check engine it (and the gate) can call.

## Contributor-only

Not added to `package.json`'s `files` array, so `create-vine` never ships it — same as `trellis-gate.sh` / `journal-check.sh`.

## Tests

`run-tests.sh` gains 8 cases: pass/fail + stamp format, init's skip path, and the legacy-ref allowlist (a stray ref warns; the fallback paragraph does not). Full suite: **19 passed, 0 failed**. Verified green against the live repo's 11 command files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)