### PR TITLE
Add main-guard.sh: contributor gate blocking commits on main

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,10 @@
           {
             "type": "command",
             "command": "sh \"$CLAUDE_PROJECT_DIR/.vine/scripts/trellis-gate.sh\""
+          },
+          {
+            "type": "command",
+            "command": "sh \"$CLAUDE_PROJECT_DIR/.vine/scripts/main-guard.sh\""
           }
         ]
       }

--- a/.vine/context/shared.md
+++ b/.vine/context/shared.md
@@ -111,6 +111,9 @@ table. Match the feature's domain against the profile's entries.
   passed since the last command edit (a green run writes `.vine/.trellis-ok`). Contributor-only:
   `create-vine` never ships this script. The journal-check scaffold hook is wired here too
   (dogfooding).
+- **Main guard hook**: `.vine/scripts/main-guard.sh` (PreToolUse on Bash, contributor-only) —
+  blocks `git commit` while the checkout is on `main`; sessions that land on the shared
+  checkout get a hard stop telling them to branch or use a worktree.
 - **Publish workflow**: `.github/workflows/publish.yml` — manual dispatch, publishes `create-vine` to npm with provenance
   - Reads version from `package.json`, extracts release notes from `CHANGELOG.md`
   - Runs smoke test (`bin/cli.js` in temp dir, verifies command files are installed)

--- a/.vine/scripts/main-guard.sh
+++ b/.vine/scripts/main-guard.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# VINE contributor main-commit guard (this repo only — NOT part of the user
+# scaffold; create-vine never copies this script).
+# PreToolUse hook on Bash: blocks `git commit` while the checkout is on
+# 'main'. Spawned/parallel sessions sometimes open on the shared checkout
+# without a worktree; this gate turns "session committed straight to main"
+# into a hard stop with instructions instead of a cleanup job.
+#
+# Fails open on missing tooling, detached HEAD, or any ambiguity.
+# POSIX sh only.
+
+root="${CLAUDE_PROJECT_DIR:-.}"
+
+payload=$(cat 2>/dev/null) || payload=""
+if command -v jq >/dev/null 2>&1; then
+  cmd=$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null) || cmd=$payload
+else
+  cmd=$payload
+fi
+case $cmd in
+  *git*commit*) ;;
+  *) exit 0 ;;
+esac
+
+branch=$(git -C "$root" symbolic-ref --short -q HEAD 2>/dev/null) || exit 0
+[ "$branch" = "main" ] || exit 0
+
+cat >&2 <<EOF
+VINE main guard: this checkout is on 'main' — commits belong on a feature
+branch. Run git checkout -b <branch> first (parallel sessions should use a
+worktree instead of the shared checkout).
+EOF
+exit 2

--- a/.vine/scripts/run-tests.sh
+++ b/.vine/scripts/run-tests.sh
@@ -83,6 +83,28 @@ check "trellis-gate: non-commit -> allow" 0 $?
 
 rm -rf "$T"
 
+# ---------- main-guard.sh ----------
+M="$SCRIPTS_DIR/main-guard.sh"
+T=$(mktemp -d)
+( cd "$T" && git init -q -b main . && git commit -q --allow-empty -m init )
+export CLAUDE_PROJECT_DIR="$T"
+
+printf '%s' "$payload_commit" | sh "$M" >/dev/null 2>&1
+check "main-guard: commit on main -> block (exit 2)" 2 $?
+
+printf '%s' "$payload_ls" | sh "$M" >/dev/null 2>&1
+check "main-guard: non-commit on main -> allow" 0 $?
+
+( cd "$T" && git checkout -q -b feat )
+printf '%s' "$payload_commit" | sh "$M" >/dev/null 2>&1
+check "main-guard: commit on feature branch -> allow" 0 $?
+
+( cd "$T" && git checkout -q --detach )
+printf '%s' "$payload_commit" | sh "$M" >/dev/null 2>&1
+check "main-guard: detached HEAD fails open -> allow" 0 $?
+
+rm -rf "$T"
+
 # ---------- trellis-check.sh ----------
 C="$SCRIPTS_DIR/trellis-check.sh"
 

--- a/references/STATE.md
+++ b/references/STATE.md
@@ -241,7 +241,7 @@ Shell-script home for VINE's native hook scripts — the enforcement layer behin
 
 Validation/lint enforcement is deliberately outside the scaffold: when and how to run a project's checks depends on its tooling, so that decision stays with the repo (native hooks in `.claude/settings.json` are available directly). If VINE grows a validation contract, the Validation block proposed in #54 is its home.
 
-A repo may carry additional scripts here beyond the user scaffold — the VINE framework repo itself keeps `trellis-gate.sh` (a contributor-only commit gate, never shipped by `create-vine`) in the same directory. The table above documents only the scaffold scripts.
+A repo may carry additional scripts here beyond the user scaffold — the VINE framework repo itself keeps contributor-only gates in the same directory (`trellis-gate.sh`, a command-commit gate, and `main-guard.sh`, which blocks commits on `main`; neither ships via `create-vine`). The table above documents only the scaffold scripts.
 
 ### PROJECT-MAP.md (produced by vine:verify, updated by all phases)
 


### PR DESCRIPTION
## What

A new contributor-only native hook gate, `.vine/scripts/main-guard.sh`, wired as the third PreToolUse (Bash) hook in the tracked `.claude/settings.json`. Same shape as trellis-gate: POSIX sh, stdin-JSON tolerant (jq optional), fails open on detached HEAD or missing tooling, and exits 2 with branch/worktree instructions when a `git commit` fires while the checkout is on `main`. Never shipped by `create-vine`.

Also: run-tests matrix grows 19 → 23 (block on main, allow non-commit, allow on feature branch, fail open on detached HEAD), plus one-line doc updates in `references/STATE.md`'s scripts note and shared.md's CI/CD section.

## Why

Parallel spawned sessions sometimes open on the shared project-root checkout instead of a worktree — several landed on `main` at once and chaos ensued. This turns "session committed straight to main" into a mechanical hard stop with instructions, instead of a forensic cleanup job. Same mechanical-teeth philosophy as the existing gates.

No issue — small contributor-tooling fix per CONTRIBUTING ("for small fixes, a PR without an issue is fine").

## How to test

- `sh .vine/scripts/run-tests.sh` — 23/23, including the four new main-guard cases.
- Live: in a fresh session on `main`, ask Claude to commit anything — the hook blocks with the branch/worktree message; switch to a branch and the same commit goes through.

## Checklist

- [ ] I've tested this in an actual VINE cycle (not applicable — contributor tooling, no command behavior changed)
- [x] Changes are focused on a single concern
- [x] Any new behavior is documented in the README or command file (STATE.md scripts note + shared.md CI/CD; contributor-only, so README is untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)