### PR TITLE
verify/inquire/navigate: nudge template-verbatim artifact headings

### DIFF
--- a/commands/vine/inquire.md
+++ b/commands/vine/inquire.md
@@ -275,6 +275,11 @@ Compile everything into the spec document:
 [External dependencies, team coordination needed, unknowns]
 ```
 
+The section headings above are the SPEC.md template headings from `references/STATE.md`.
+Use them verbatim. Extending a heading with subtitle text after a colon or dash is fine;
+replacing or rewording the heading itself is not. Navigate and artifact-format validation
+locate sections by these headings, so a custom heading breaks the chain silently.
+
 Save to `.vine/projects/<domain>/<feature-slug>/SPEC.md`.
 
 ## Important Principles

--- a/commands/vine/navigate.md
+++ b/commands/vine/navigate.md
@@ -284,6 +284,12 @@ stronger than that. For each slice, capture:
   - Claude → Engineer: [patterns or approaches the engineer found useful]
 ```
 
+The slice-heading shape and field labels above are the NAVIGATION.md template from
+`references/STATE.md`. Use them verbatim: keep the `Slice N:` prefix, the literal
+`In Progress` / `Complete` status words (pause matches on them), and the field labels as
+written. Resume, pause, and artifact-format validation locate entries by these strings, so
+a custom heading or relabeled field breaks the chain silently.
+
 **c. Commit the slice**
 
 Stage the changed files and commit with this format. **When the repo tracks `.vine/`

--- a/commands/vine/verify.md
+++ b/commands/vine/verify.md
@@ -227,6 +227,12 @@ Structure:
 [Anything unresolved that vine:inquire needs to address]
 ```
 
+The section headings above are the CONTEXT.md template headings from `references/STATE.md`.
+Use them verbatim. Extending a heading with subtitle text after a colon or dash (e.g.,
+`### Current State — Drift Findings`) is fine; replacing or rewording the heading itself is
+not. Downstream phases and artifact-format validation locate sections by these headings, so
+a custom heading breaks the chain silently.
+
 Save this to a domain-namespaced directory under `.vine/projects/`. The path follows the pattern:
 `.vine/projects/<domain>/<feature-slug>/CONTEXT.md`
 


### PR DESCRIPTION
## What

Adds a short instruction to verify, inquire, and navigate, right after each command's inline artifact structure: use the section headings from the `references/STATE.md` template verbatim. Extending a heading with subtitle text after a colon or dash is fine; replacing the heading is not. Navigate's version also names the literal strings other commands match on (`Slice N:` prefix, `In Progress` / `Complete`).

## Why

vine:verify recently emitted a CONTEXT.md with invented section headings, and the drift was only caught later by `/trellis` — a repo without that check would ship non-template artifacts silently. Downstream phases and validation locate sections by these headings, so they need to be right at creation time.

Closes #80

## How to test

1. Run `/vine:verify` on a repo through CONTEXT.md creation.
2. Check the section headings match the CONTEXT.md template in `references/STATE.md`.
3. `/trellis` passes 11/11 commands on this branch.

## Checklist

- [ ] I've tested this in an actual VINE cycle (if changing command behavior)
- [x] Changes are focused on a single concern
- [x] Any new behavior is documented in the README or command file

🤖 Generated with [Claude Code](https://claude.com/claude-code)