### PR TITLE
trellis: delegate the pass stamp to trellis-check.sh

### DIFF
--- a/.claude/commands/trellis.md
+++ b/.claude/commands/trellis.md
@@ -6,7 +6,7 @@ allowed-tools:
   - Read
   - Glob
   - Grep
-  - Write
+  - Bash
   - AskUserQuestion
 ---
 
@@ -366,25 +366,29 @@ If all checks pass and there are uncommitted changes to command files, suggest:
 
 > "All checks pass. If you're ready to submit, run `/pr` to create a pull request."
 
-## Step 8: Write the Pass Stamp
+## Step 8: Stamp the Run (script-owned)
 
-Write `.vine/.trellis-ok` (gitignored via `.vine/*`) recording this run's command-validation
-outcome. The contributor trellis gate (`.vine/scripts/trellis-gate.sh`, wired in this repo's
-`.claude/settings.json`) reads it before allowing commits that touch `commands/vine/` — a
-green trellis run is the commit ticket for command changes.
+Do **not** write `.vine/.trellis-ok` yourself. The stamp is produced mechanically by the
+check engine so it can't be confused with a hand-written pass ticket — run it with Bash:
 
-- **If command validation (Steps 1–4) finished with zero failures**, write:
+```
+sh .vine/scripts/trellis-check.sh
+```
 
-  ```
-  status: pass
-  checked: [YYYY-MM-DD HH:MM]
-  summary: [the Step 4 summary line]
-  ```
+The script re-runs the command checks (Steps 1–4) mechanically over `commands/vine/*.md`
+and writes `.vine/.trellis-ok` (gitignored via `.vine/*`) itself — `status: pass` and
+exit 0 on a green run, `status: fail` and exit 1 otherwise, overwriting any previous stamp
+so a red tree can't ride through the gate on a stale green. The contributor trellis gate
+(`.vine/scripts/trellis-gate.sh`, wired in this repo's `.claude/settings.json`) reads that
+stamp before allowing commits that touch `commands/vine/` — a green script run is the
+commit ticket for command changes.
 
-- **If any command check failed**, write the same format with `status: fail` — overwriting a
-  previous pass stamp so a red tree can't ride through the gate on a stale green.
+If the script's verdict disagrees with your Step 4 results, the script wins for gating
+purposes — report the divergence to the contributor, since it usually means a check has
+drifted between this skill and `trellis-check.sh` and the drift itself needs fixing.
 
 Scope notes: warnings (legacy references, unmarked headings) do not block a pass stamp.
 Artifact validation failures don't either — artifacts are often work-in-progress journals,
 and gating command commits on artifact state would block unrelated work. The stamp certifies
-command structure only.
+command structure only; artifact validation (Steps 5–7) stays session-judged and is not
+stamped.

--- a/references/STATE.md
+++ b/references/STATE.md
@@ -241,7 +241,7 @@ Shell-script home for VINE's native hook scripts — the enforcement layer behin
 
 Validation/lint enforcement is deliberately outside the scaffold: when and how to run a project's checks depends on its tooling, so that decision stays with the repo (native hooks in `.claude/settings.json` are available directly). If VINE grows a validation contract, the Validation block proposed in #54 is its home.
 
-A repo may carry additional scripts here beyond the user scaffold — the VINE framework repo itself keeps contributor-only gates in the same directory (`trellis-gate.sh`, a command-commit gate, and `main-guard.sh`, which blocks commits on `main`; neither ships via `create-vine`). The table above documents only the scaffold scripts.
+A repo may carry additional scripts here beyond the user scaffold — the VINE framework repo itself keeps contributor-only tooling in the same directory (`trellis-check.sh`, the mechanical check engine that runs trellis's command checks and writes the `.vine/.trellis-ok` stamp; `trellis-gate.sh`, the command-commit gate that reads that stamp; and `main-guard.sh`, which blocks commits on `main`; none ship via `create-vine`). The table above documents only the scaffold scripts.
 
 ### PROJECT-MAP.md (produced by vine:verify, updated by all phases)
 


### PR DESCRIPTION
## What

`/trellis` no longer asks the model to hand-write the `.vine/.trellis-ok` pass stamp. Step 8 now runs `.vine/scripts/trellis-check.sh`, which performs the command checks mechanically and writes the stamp itself; the skill's frontmatter swaps `Write` for `Bash`. `references/STATE.md` now documents all three contributor scripts.

## Why

In auto permission mode, the model writing its own pass stamp is indistinguishable from forging a sentinel to bypass the commit gate — the permission classifier denied a real green run on 2026-06-11. Making the script the only stamp writer removes that ambiguity. Completes the skill-side wiring planned in #70 (the check engine landed via #77); extending mechanical checks to artifacts is tracked in #81.

## How to test

1. Run `sh .vine/scripts/trellis-check.sh` — expect `✅ 11/11 commands pass all checks`, exit 0, and a `status: pass` stamp.
2. Break a frontmatter field in a scratch copy of the repo and rerun with `CLAUDE_PROJECT_DIR=<scratch>` — expect `status: fail`, exit 1.
3. Run `/trellis` — Step 8 should call the script instead of writing the stamp.

## Checklist

- [ ] I've tested this in an actual VINE cycle (n/a — contributor skill + docs only; no `commands/vine/` behavior changed)
- [x] Changes are focused on a single concern
- [x] Any new behavior is documented in the README or command file

🤖 Generated with [Claude Code](https://claude.com/claude-code)