### PR TITLE
Add a visitor-readable intro to the roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,29 @@
 # VINE Roadmap
 
-The issue-level source of truth is the
-[v0.4.0 milestone](https://github.com/moduloMoments/VINE/milestone/1). This file names the
-VINE cycles that deliver it, their order, and why the order matters. Each cycle is run as a
+## Where this is headed
+
+VINE today is a workflow for one engineer and Claude building features together, with the
+human reviewing everything. v0.4.0 turns that into a **delegation harness**: for each piece
+of work, VINE helps decide how much human attention it deserves — from "walk me through every
+change" to "run this unattended and hand the result to a reviewer" — and routes it
+accordingly. The human stays the one deciding what's safe to delegate; VINE's job is making
+that decision well-informed, recording it, and learning from how it turns out.
+
+In practice, v0.4.0 builds four things:
+
+- **Routing rules** — clear criteria for which work qualifies for unattended runs, and a
+  default where VINE recommends and the human approves.
+- **Handoff records** — enough written down that a reviewer can check work they didn't
+  watch happen.
+- **Shared configuration** — team conventions that install with the project instead of
+  living in one person's head.
+- **Multi-actor safety** — clear ownership when several people (or agents) work in one
+  repo at once.
+
+The rest of this file is the working contract for the cycles that deliver this — future
+development sessions execute against it, so the detail level below is intentional. Issue-level
+status lives in the [v0.4.0 milestone](https://github.com/moduloMoments/VINE/milestone/1);
+this file names the cycles, their order, and why the order matters. Each cycle is run as a
 VINE feature on this repo (dogfooding is the test suite); small mechanical items go through
 `vine:pair` instead of the full chain.
 


### PR DESCRIPTION
## What

Adds a plain-language "Where this is headed" section to the top of ROADMAP.md. The contract detail below it is unchanged and now flagged as intentional.

## Why

A visitor hitting the roadmap got contract-grade density from line one. The new intro explains the v0.4.0 direction (a delegation harness: deciding how much human attention each piece of work deserves) and the four things being built, in everyday terms.

This commit was written on the delegation-routing branch but missed the #82 merge.

## How to test

- Read the new intro cold — it should make sense with zero VINE context.
- Confirm the backward-compatibility paragraph and everything below the intro is untouched (diff is 24 insertions at the top, 3 lines reflowed).

## Checklist

- [x] I've tested this in an actual VINE cycle (if changing command behavior) — docs only, no command behavior changed
- [x] Changes are focused on a single concern
- [x] Any new behavior is documented in the README or command file — n/a, docs change itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)
