### PR TITLE
verify+inquire: commit tracked artifacts at phase completion

### DIFF
--- a/commands/vine/inquire.md
+++ b/commands/vine/inquire.md
@@ -323,7 +323,12 @@ Once approved:
 
 1. Update PROJECT-MAP.md (if it exists) — set the inquire row to ✅ with today's date.
 
-2. Persist actionable retro items before printing the completion block. The retro is
+2. If the repo tracks artifacts (`git check-ignore -q .vine/projects` exits non-zero), commit
+   SPEC.md and the PROJECT-MAP.md update (see "Committing Artifacts" in `references/STATE.md`).
+   If the path is gitignored, skip this step silently — personal-scope artifacts never enter
+   a commit.
+
+3. Persist actionable retro items before printing the completion block. The retro is
    conversation output and doesn't survive `/clear` — if a retro item should change what
    navigate builds (a slice criterion, a convention to record, a framing a rule needs),
    fold it into the relevant slice in SPEC.md now. Only items with no downstream action

--- a/commands/vine/verify.md
+++ b/commands/vine/verify.md
@@ -9,6 +9,7 @@ allowed-tools:
   - Agent
   - WebFetch
   - Write
+  - Bash
   - AskUserQuestion
 ---
 
@@ -307,12 +308,16 @@ When you and the engineer feel you have a solid understanding of the landscape, 
    Save to `.vine/projects/<domain>/<feature-slug>/PROJECT-MAP.md`. No Milestones table yet —
    that's added by inquire if the feature needs multi-PR treatment.
 
-3. Highlight the open questions that need resolution in inquire
-4. Persist actionable retro items before printing the completion block. The retro is
+3. If the repo tracks artifacts (`git check-ignore -q .vine/projects` exits non-zero), commit
+   CONTEXT.md and PROJECT-MAP.md now — this is their first entry into history (see "Committing
+   Artifacts" in `references/STATE.md`). If the path is gitignored, skip this step silently —
+   personal-scope artifacts never enter a commit.
+4. Highlight the open questions that need resolution in inquire
+5. Persist actionable retro items before printing the completion block. The retro is
    conversation output and doesn't survive `/clear` — anything inquire should act on
    belongs in the relevant CONTEXT.md section (open questions, tribal knowledge,
    documentation gaps), not just the retro.
-5. Suggest next step:
+6. Suggest next step:
 
 ```
 ---

--- a/references/STATE.md
+++ b/references/STATE.md
@@ -406,6 +406,8 @@ The journal-before-commit guarantee holds either way: `journal-check.sh` compare
 
 | Commit point | Carries (code) | Carries (tracked artifacts) |
 |--------------|----------------|------------------------------|
+| **Verify completion** (`vine:verify` wrap-up, after the engineer approves) | — | CONTEXT.md + PROJECT-MAP.md — their first entry into history |
+| **Inquire completion** (`vine:inquire` sign-off) | — | SPEC.md + the PROJECT-MAP.md inquire row |
 | **Slice commit** (`vine:navigate` step 4c) | the slice's code | that slice's NAVIGATION.md journal entry + any SPEC.md deviation annotations made during the slice (step 6) |
 | **Phase-group boundary** (`vine:navigate` step 8) | — | PROJECT-MAP.md (navigate row, Milestones row → status / PR#) + the SPEC.md phase-group ✅ marker |
 | **Evolve commit** (`vine:evolve`) | — | EVOLUTION.md and the `.resolved` marker |


### PR DESCRIPTION
## What

`vine:verify` now commits CONTEXT.md + PROJECT-MAP.md after the engineer approves them at wrap-up, and `vine:inquire` commits SPEC.md + the PROJECT-MAP.md update at sign-off — but only when the repo tracks `.vine/projects/`. The "Committing Artifacts" table in `references/STATE.md` gains both commit points so it stays the source of truth.

## Why

When artifacts are tracked (the team-shared choice), nothing said when CONTEXT.md, SPEC.md, or PROJECT-MAP.md first enter history — they rode along implicitly with later slice commits. Now each artifact is committed at the moment the engineer approves it. The gate is mechanical (`git check-ignore -q .vine/projects`); repos that gitignore artifacts skip silently with no warning and no behavior change.

This touches the verify/inquire completion flow — a maintainer design decision (2026-06-11), not an outside contribution to the core phase flow.

## How to test

1. In a repo where `.vine/projects/` is tracked, run `vine:verify` to completion — CONTEXT.md and PROJECT-MAP.md are committed after approval.
2. Run `vine:inquire` to sign-off — SPEC.md and the PROJECT-MAP.md update are committed.
3. In a repo that gitignores `.vine/projects/`, both commands complete with no commit and no warning.

## Checklist

- [ ] I've tested this in an actual VINE cycle (if changing command behavior)
- [x] Changes are focused on a single concern
- [x] Any new behavior is documented in the README or command file

🤖 Generated with [Claude Code](https://claude.com/claude-code)