### PR TITLE
Make next-step suggestions copy-pastable (/vine: + fenced blocks)

### DIFF
--- a/commands/vine/evolve.md
+++ b/commands/vine/evolve.md
@@ -51,7 +51,8 @@ Identify the feature directory under `.vine/projects/` (e.g., `.vine/projects/pa
 there are multiple feature directories, use `AskUserQuestion` to let the engineer pick which
 feature to review. Filter out resolved projects (directories containing a `.resolved` file) and
 archived projects (under `.vine/projects/.archive/`). If all projects are resolved or archived,
-tell the engineer and suggest starting a new cycle with `vine:verify`.
+tell the engineer and suggest starting a new cycle with `/vine:verify` — present the command
+in its own fenced code block so it's copy-pastable.
 
 Read all VINE artifacts for this feature:
 - `.vine/projects/<domain>/<feature-slug>/CONTEXT.md` (the landscape)
@@ -67,7 +68,7 @@ table, note which phases shipped in prior PRs — evolve's verification should f
 phase group and cross-phase integration, not re-verify already-shipped work.
 
 If the feature directory contains a PAUSE.md, picking the work back up consumes it: surface
-its notes, then delete the file — a consumed pause must not linger suggesting `vine:resume`.
+its notes, then delete the file — a consumed pause must not linger suggesting `/vine:resume`.
 Also delete `.vine/ACTIVE` (repo root) if it exists: any navigate session on this feature is
 over, and a stale sentinel keeps installed hooks firing against work that's no longer active
 (format and lifecycle in `references/STATE.md`).

--- a/commands/vine/inquire.md
+++ b/commands/vine/inquire.md
@@ -54,14 +54,15 @@ Identify the feature directory under `.vine/projects/`. Look for the domain/feat
 containing a `.resolved` file) and archived projects (under `.vine/projects/.archive/`). If
 there's only one active feature directory, use that. If there are multiple, use
 `AskUserQuestion` to let the engineer pick which feature to work on. If all projects are
-resolved or archived, tell the engineer and suggest starting a new cycle with `vine:verify`.
+resolved or archived, tell the engineer and suggest starting a new cycle with `/vine:verify` —
+present the command in its own fenced code block so it's copy-pastable.
 
 Also read `.vine/projects/<domain>/<feature-slug>/PROJECT-MAP.md` if it exists. If present, update the
 inquire row to 🚧 with today's date. If it doesn't exist, skip — older projects won't have one.
 
 Read `.vine/projects/<domain>/<feature-slug>/CONTEXT.md` from the project. If it doesn't exist, tell the engineer:
 
-> "I don't see a CONTEXT.md from a verify phase. We can either run vine:verify first to map the
+> "I don't see a CONTEXT.md from a verify phase. We can either run /vine:verify first to map the
 > landscape, or if you're confident we have enough context, I can work from what you tell me.
 > What do you prefer?"
 
@@ -73,7 +74,7 @@ If CONTEXT.md exists, read it and summarize the key points back to the engineer:
 **Consume any pause state.** If the feature directory contains a PAUSE.md (e.g., the engineer
 paused after verify), surface its notes alongside the summary above, then delete it — the
 consumed-once rule (see `references/STATE.md`). A consumed pause must not linger: it would keep
-suggesting `vine:resume` for work that has already resumed. Anything worth keeping past this
+suggesting `/vine:resume` for work that has already resumed. Anything worth keeping past this
 session belongs in the artifacts, not PAUSE.md. (If no PAUSE.md is present, skip.)
 
 ### 2. Resolve Open Questions
@@ -334,14 +335,18 @@ Once approved:
    fold it into the relevant slice in SPEC.md now. Only items with no downstream action
    belong in the retro alone.
 
-```
+````
 ---
 ✅ vine:inquire complete → SPEC.md written to .vine/projects/<domain>/<feature-slug>/SPEC.md
-📋 Suggested next step: Run `vine:navigate <domain>/<feature-slug>` to begin implementation.
+📋 Suggested next step: Run /vine:navigate to begin implementation.
    Starting with [Phase 1: name / Slice 1: name]
    [1-2 sentence summary of what's first]
 
-🔄 Recommended: Run `/clear` before starting vine:navigate.
+```
+/vine:navigate <domain>/<feature-slug>
+```
+
+🔄 Recommended: Run `/clear` before starting /vine:navigate.
    Inquire is analytical — navigate needs a tactical, implementation-focused headspace.
    SPEC.md carries everything forward; conversation context doesn't need to.
 
@@ -350,4 +355,4 @@ Once approved:
    - Skill suggestion: [any design pattern that could be templated]
    - User note: [any architectural concepts the engineer found useful to discuss]
 ---
-```
+````

--- a/commands/vine/navigate.md
+++ b/commands/vine/navigate.md
@@ -70,7 +70,8 @@ Identify the feature directory under `.vine/projects/` (e.g., `.vine/projects/pa
 there are multiple feature directories, use `AskUserQuestion` to let the engineer pick which
 feature to work on. Filter out resolved projects (directories containing a `.resolved` file) and
 archived projects (under `.vine/projects/.archive/`). If all projects are resolved or archived,
-tell the engineer and suggest starting a new cycle with `vine:verify`.
+tell the engineer and suggest starting a new cycle with `/vine:verify` — present the command
+in its own fenced code block so it's copy-pastable.
 
 Read `.vine/projects/<domain>/<feature-slug>/CONTEXT.md` and `.vine/projects/<domain>/<feature-slug>/SPEC.md`. If either is
 missing, tell the engineer which prior phase needs to run first.
@@ -100,7 +101,7 @@ active work. It never leaves the machine.
 
 **Consume any pause state.** If the feature directory contains a PAUSE.md, picking the work
 back up consumes it: surface its notes in your starting-point summary, then delete the file.
-A consumed pause must not linger — it would keep suggesting `vine:resume` for work that has
+A consumed pause must not linger — it would keep suggesting `/vine:resume` for work that has
 already resumed.
 
 **Build the live task view (when available).** If native task tools are available in this
@@ -387,10 +388,15 @@ After each slice is validated and committed:
 **If the engineer chooses `/clear` and continue fresh**, this is a continuation, not an ending.
 NAVIGATION.md is already current (you updated it at the slice commit), so nothing extra to write —
 the re-invoked `/vine:navigate` rebuilds context from it. Leave `.vine/ACTIVE` in place; the next
-invocation refreshes its `phase` line. Then tell the engineer the exact command to run:
+invocation refreshes its `phase` line. Then tell the engineer the exact command to run — the
+message, followed by the command in its own fenced code block so it's copy-pastable:
 
-> "Slice N committed. Run `/clear`, then `/vine:navigate <domain>/<feature-slug>` — it'll pick up
-> at Slice N+1 with a fresh context. NAVIGATION.md carries everything forward."
+> "Slice N committed. Run `/clear`, then /vine:navigate — it'll pick up at Slice N+1 with a
+> fresh context. NAVIGATION.md carries everything forward."
+
+```
+/vine:navigate <domain>/<feature-slug>
+```
 
 **If the engineer chooses to pause**, write a "Remaining Work" section to NAVIGATION.md before
 stopping. This ensures the next session (or vine:resume) has structured handoff context:
@@ -403,12 +409,17 @@ stopping. This ensures the next session (or vine:resume) has structured handoff 
   anything that won't be obvious from the slice entries alone]
 ```
 
-After writing Remaining Work, suggest running `vine:pause` to capture the engineer's notes:
+After writing Remaining Work, suggest running `/vine:pause` to capture the engineer's notes —
+the message, followed by the command in its own fenced code block so it's copy-pastable:
 
 > "NAVIGATION.md updated with remaining work. If you want to capture any personal notes
-> for when you come back, run `vine:pause <domain>/<feature-slug>` before closing the session."
+> for when you come back, run /vine:pause before closing the session."
 
-Then delete `.vine/ACTIVE` — the navigate session is ending. (`vine:pause` also clears the
+```
+/vine:pause <domain>/<feature-slug>
+```
+
+Then delete `.vine/ACTIVE` — the navigate session is ending. (`/vine:pause` also clears the
 sentinel; deleting it here covers the engineer who pauses without running the command.)
 
 ### 8. Between Phase Groups
@@ -556,19 +567,23 @@ the retro.
 
 Then present the completion block:
 
-```
+````
 ---
 ✅ vine:navigate complete → .vine/projects/<domain>/<feature-slug>/NAVIGATION.md updated
    Slices completed: [N of M]
    Commits: [list of commit hashes]
 
-📋 Suggested next step: Run `vine:evolve <domain>/<feature-slug>` to verify integration and capture learnings.
+📋 Suggested next step: Run /vine:evolve to verify integration and capture learnings.
    Key items for evolve:
    - [spec deviations to review]
    - [cross-slice integration to verify]
    - [discovered items to triage]
 
-🔄 Recommended: Run `/clear` before starting vine:evolve.
+```
+/vine:evolve <domain>/<feature-slug>
+```
+
+🔄 Recommended: Run `/clear` before starting /vine:evolve.
    Navigate is tactical — evolve needs a reflective, evaluative headspace.
    NAVIGATION.md carries everything forward; conversation context doesn't need to.
 
@@ -577,4 +592,4 @@ Then present the completion block:
    - Skill suggestion: [any implementation pattern worth automating]
    - User note: [techniques or patterns the engineer engaged with most]
 ---
-```
+````

--- a/commands/vine/resume.md
+++ b/commands/vine/resume.md
@@ -47,7 +47,8 @@ to re-read everything yourself.
 Scan `.vine/projects/` for feature directories. Filter out resolved projects (directories
 containing a `.resolved` file) and archived projects (under `.vine/projects/.archive/`). If all
 projects are resolved or archived, tell the engineer there's nothing to resume and suggest
-starting a new cycle with `vine:verify`.
+starting a new cycle with `/vine:verify` — present the command in its own fenced code block
+so it's copy-pastable.
 
 If a feature path was passed as an argument, use it directly. Otherwise:
 
@@ -96,7 +97,7 @@ exists.
 
 ### With PAUSE.md
 
-```
+````
 ---
 🔄 Resuming: [Feature Name]
    Paused: [timestamp] ([time ago])
@@ -122,10 +123,13 @@ exists.
 ⚠️  Spec deviations so far:
    [List of deviations]
 
-📋 Recommended next step: Run /vine:[next command] <domain>/<feature-slug>
-   [1-2 sentence explanation of why this is the right next step]
----
+📋 Recommended next step: [1-2 sentence explanation of why this is the right next step]
+
 ```
+/vine:[next command] <domain>/<feature-slug>
+```
+---
+````
 
 ### PR Number Backfill
 
@@ -141,7 +145,7 @@ Skip this if no Milestones table exists or all PR numbers are already filled in.
 
 ### Without PAUSE.md (artifact-only fallback)
 
-```
+````
 ---
 🔄 Resuming: [Feature Name]
    Phase: [detected from artifacts]
@@ -160,15 +164,18 @@ Skip this if no Milestones table exists or all PR numbers are already filled in.
 📋 Navigation progress:
    [List slices with status: ✅ complete / 🔲 pending / ▶️ in progress]
 
-📋 Recommended next step: Run /vine:[next command] <domain>/<feature-slug>
-   [1-2 sentence explanation of why this is the right next step]
----
+📋 Recommended next step: [1-2 sentence explanation of why this is the right next step]
+
 ```
+/vine:[next command] <domain>/<feature-slug>
+```
+---
+````
 
 ## Restore Session State
 
 **Rebuild the live task view (when available).** If native task tools are available, rebuild
-the in-session task list to match what `vine:navigate` would create (see navigate's "Build the
+the in-session task list to match what `/vine:navigate` would create (see navigate's "Build the
 live task view" step): `TaskCreate` one task per remaining slice in the current phase group,
 titled by the slice name, `blockedBy`-ordered, skipping slices already `Complete` in
 NAVIGATION.md and prefixing conditional slices `(conditional: <condition>)`. If a slice is
@@ -179,7 +186,7 @@ this; the status summary above is the progress view.
 
 **Consume the pause state.** If you read and displayed a PAUSE.md, delete it now — the
 consumed-once rule (see `references/STATE.md`): a lingering pause keeps re-suggesting
-`vine:resume` and re-presents stale notes on the next resume. Its notes have already been
+`/vine:resume` and re-presents stale notes on the next resume. Its notes have already been
 surfaced in the summary above; anything worth keeping past this resume belongs in
 NAVIGATION.md's Remaining Work, not PAUSE.md. (If no PAUSE.md was present, skip — nothing to
 consume.)
@@ -190,12 +197,12 @@ Based on the detected phase, recommend the appropriate command:
 
 | Phase | Recommendation |
 |---|---|
-| pre-verify | `vine:verify` — start the context-building spike |
-| verify complete | `vine:inquire <domain>/<feature-slug>` — build the feature spec |
-| inquire complete | `vine:navigate <domain>/<feature-slug>` — start implementation |
-| navigate in progress | `vine:navigate <domain>/<feature-slug>` — resume implementation (it reads NAVIGATION.md) |
-| navigate complete | `vine:evolve <domain>/<feature-slug>` — verify integration and capture learnings |
-| evolve in progress | `vine:evolve <domain>/<feature-slug>` — finish the evolution report |
+| pre-verify | `/vine:verify` — start the context-building spike |
+| verify complete | `/vine:inquire <domain>/<feature-slug>` — build the feature spec |
+| inquire complete | `/vine:navigate <domain>/<feature-slug>` — start implementation |
+| navigate in progress | `/vine:navigate <domain>/<feature-slug>` — resume implementation (it reads NAVIGATION.md) |
+| navigate complete | `/vine:evolve <domain>/<feature-slug>` — verify integration and capture learnings |
+| evolve in progress | `/vine:evolve <domain>/<feature-slug>` — finish the evolution report |
 | evolve complete | Consider resolving the project or re-running evolve |
 
 **Do not auto-launch the recommended command.** The engineer decides when to proceed. Resume
@@ -223,7 +230,8 @@ shows Slice 3 is complete, trust the artifacts over PAUSE.md. Note the discrepan
 > "Your pause state says you were on Slice 3, but it looks like it was completed since then.
 > Picking up at Slice 4 instead."
 
-**No active features**: Tell the engineer and suggest `vine:verify` to start a new cycle.
+**No active features**: Tell the engineer and suggest `/vine:verify` to start a new cycle —
+present the command in its own fenced code block so it's copy-pastable.
 
 **Wrong branch**: If the current branch doesn't match the feature, suggest switching:
 

--- a/commands/vine/status.md
+++ b/commands/vine/status.md
@@ -35,7 +35,7 @@ display command.
 
 ---
 
-A lightweight alternative to `vine:resume`. Shows where a feature stands without reconstructing
+A lightweight alternative to `/vine:resume`. Shows where a feature stands without reconstructing
 full session state or recommending next steps. Useful for a quick check between sessions or
 when deciding which feature to pick up.
 
@@ -123,4 +123,4 @@ exists in the session (e.g., status run alongside an active navigate), status ma
 
 **No recommendations.** Unlike resume, status doesn't suggest next steps or load PAUSE.md.
 It answers "where does this stand?" and nothing more. If the engineer wants guidance, they
-should run `vine:resume <domain>/<feature-slug>`.
+should run `/vine:resume <domain>/<feature-slug>`.

--- a/commands/vine/verify.md
+++ b/commands/vine/verify.md
@@ -167,7 +167,7 @@ Use `AskUserQuestion`:
    documentation trail."
 
 If the engineer chooses pair, summarize the key context gathered so far (landscape, tribal
-knowledge, the change to make) and transition directly into `vine:pair`'s implementation
+knowledge, the change to make) and transition directly into `/vine:pair`'s implementation
 flow. The verify conversation *is* the context — no CONTEXT.md needed.
 
 If the work clearly warrants the full cycle, skip this check — don't ask the question when
@@ -319,16 +319,20 @@ When you and the engineer feel you have a solid understanding of the landscape, 
    documentation gaps), not just the retro.
 6. Suggest next step:
 
-```
+````
 ---
 ✅ vine:verify complete → CONTEXT.md + PROJECT-MAP.md written to .vine/projects/<domain>/<feature-slug>/
-📋 Suggested next step: Run `vine:inquire <domain>/<feature-slug>` to build the feature spec.
+📋 Suggested next step: Run /vine:inquire to build the feature spec.
    Key items to address:
    - [open question 1]
    - [open question 2]
    - [tech debt decision needed]
 
-🔄 Recommended: Run `/clear` before starting vine:inquire.
+```
+/vine:inquire <domain>/<feature-slug>
+```
+
+🔄 Recommended: Run `/clear` before starting /vine:inquire.
    Verify is exploratory — inquire needs a clean, decisive headspace.
    CONTEXT.md carries everything forward; conversation context doesn't need to.
 
@@ -343,7 +347,7 @@ When you and the engineer feel you have a solid understanding of the landscape, 
    - Skill suggestion: [any repeated pattern worth codifying]
    - User note: [anything the engineer mentioned wanting to learn more about]
 ---
-```
+````
 
 The retro block at the end is part of VINE's evolution philosophy. Every phase is an opportunity
 to improve three things: the product, the agent's knowledge, and the user's growth.

--- a/references/STATE.md
+++ b/references/STATE.md
@@ -176,7 +176,7 @@ The triple evolution report. Captures growth across product, agent, and user.
 
 ### PAUSE.md (produced by vine:pause, consumed by vine:resume)
 
-An ephemeral session artifact. Captures where the engineer stopped and why — the context that existing artifacts don't preserve. Unlike other state files, PAUSE.md is **consumed-once**: it exists only between the pause and whatever picks the work back up. The command that resumes the work deletes it — a consumed pause that lingers keeps firing the "PAUSE.md exists → suggest `vine:resume`" suggestion and re-presents stale notes on the next resume.
+An ephemeral session artifact. Captures where the engineer stopped and why — the context that existing artifacts don't preserve. Unlike other state files, PAUSE.md is **consumed-once**: it exists only between the pause and whatever picks the work back up. The command that resumes the work deletes it — a consumed pause that lingers keeps firing the "PAUSE.md exists → suggest `/vine:resume`" suggestion and re-presents stale notes on the next resume.
 
 ```markdown
 # Paused: [Feature Name]
@@ -453,21 +453,25 @@ Commands that present feature directory lists via `AskUserQuestion` must:
 
 1. Skip directories containing a `.resolved` file
 2. Skip anything under `.vine/projects/.archive/`
-3. If all projects are resolved/archived, tell the engineer and suggest starting a new cycle with `vine:verify`
+3. If all projects are resolved/archived, tell the engineer and suggest starting a new cycle with `/vine:verify` — present the command in its own fenced code block so it's copy-pastable
 
 If the engineer needs to access a resolved project, they can pass its path explicitly as an argument.
 
 ## Chaining Protocol
 
-Each phase ends with a **Next Step Suggestion** that tells the user exactly what to run next and why. Each phase also suggests starting a fresh session (`/clear`) so state flows through `.vine/` files rather than chat context:
+Each phase ends with a **Next Step Suggestion** that tells the user exactly what to run next and why. The runnable command gets its own fenced code block so the engineer can copy it directly. Each phase also suggests starting a fresh session (`/clear`) so state flows through `.vine/` files rather than chat context:
 
-```
+````
 ---
 ✅ vine:verify complete → CONTEXT.md written
 📋 Suggested next step: /clear, then run /vine:inquire to build the feature spec on top of this context.
    Key items for inquire to address: [list open questions from CONTEXT.md]
----
+
 ```
+/vine:inquire <domain>/<feature-slug>
+```
+---
+````
 
 This is a suggestion, not an auto-trigger. The engineer decides when to proceed.
 


### PR DESCRIPTION
## What

Next-step suggestions in the six command files that lacked it (status, resume, evolve, navigate, verify, inquire) now use the runnable `/vine:` form, and every "run this next" suggestion puts the command in its own fenced code block. Completion-block templates switch to four-backtick outer fences so the nested block survives rendering. STATE.md's Chaining Protocol example shows the new shape.

## Why

Suggestions like ``Run `vine:inquire <domain>/<feature-slug>` `` can't be pasted directly (no leading slash), and inline code renders without a copy button. With the slash and a dedicated fenced block, the UI surfaces a copy button on the exact command to run. optimize.md already used the `/vine:` form — this brings the rest in line.

## How to test

1. Run a phase command (e.g. `/vine:inquire`) to completion — the suggested next step should end with a copyable `/vine:...` code block.
2. Run `/trellis` — 11/11 commands pass, all cross-reference anchors resolve.

## Checklist

- [ ] I've tested this in an actual VINE cycle (if changing command behavior)
- [x] Changes are focused on a single concern
- [x] Any new behavior is documented in the README or command file

🤖 Generated with [Claude Code](https://claude.com/claude-code)