### PR TITLE
tests: fix run-tests.sh fixtures broken by Check 10

### DIFF
--- a/.vine/scripts/run-tests.sh
+++ b/.vine/scripts/run-tests.sh
@@ -134,9 +134,28 @@ Read the profile. Decisions use AskUserQuestion.
 EOF
 }
 
+# Check 10 resolves the PAIRS list in trellis-check.sh against
+# $CLAUDE_PROJECT_DIR, so the fixture stubs every anchor. Keep in sync with
+# that heredoc. The navigate/evolve anchors live in command files, so those
+# stubs must also pass the per-command checks — mkcmd builds them.
+mkanchors() {
+  mkdir -p "$1/references" "$1/agents"
+  printf '%s\n' '**Verification-tier contract.**' > "$1/references/STATE.md"
+  cat > "$1/agents/vine-verification.md" <<'EOF'
+### Feature Verification (cross-change)
+**Phase-group scope**
+**Full-feature scope**
+**Base checks**
+**Cross-cutting checks**
+EOF
+  mkcmd "$1" navigate "vine:navigate" navigate "See the verification-tier contract note."
+  mkcmd "$1" evolve "vine:evolve" evolve "See the verification-tier contract note."
+}
+
 T=$(mktemp -d)
 mkdir -p "$T/commands/vine" "$T/.vine"
 export CLAUDE_PROJECT_DIR="$T"
+mkanchors "$T"
 
 mkcmd "$T" good "vine:good" good ""
 sh "$C" >/dev/null 2>&1
@@ -183,6 +202,11 @@ mkcmd "$T" fb "vine:fb" fb "If \`.vine/context/\` doesn't exist but legacy \`.vi
 warnout=$(sh "$C" 2>/dev/null)
 printf '%s' "$warnout" | grep -q 'fb.md:.*\.vine/hooks'
 check "trellis-check: allowlisted fallback paragraph does not warn" 1 $?
+
+# Check 10: a missing anchor file must flip the run red.
+rm "$T/references/STATE.md"
+sh "$C" >/dev/null 2>&1
+check "trellis-check: missing cross-reference anchor -> fail (exit 1)" 1 $?
 
 rm -rf "$T"
 


### PR DESCRIPTION
## What

#86 added Check 10 to `trellis-check.sh`: it resolves a list of file|anchor pairs (STATE.md, the verification agent, navigate/evolve) against the repo root. The test suite's trellis-check fixture is a bare temp dir without those files, so Check 10 failed there and all four expected-pass trellis-check tests broke (19 passed, 4 failed). The real-repo run was always green.

## Why this fix

`run-tests.sh` now stubs every anchor file in the fixture — navigate.md and evolve.md are built with the existing `mkcmd` helper so they also pass the per-command checks. To keep the fixture honest (not just silencing Check 10), a new negative test deletes an anchor file and asserts the run goes red.

## How to test

1. `sh .vine/scripts/run-tests.sh` — expect 24 passed, 0 failed
2. `sh .vine/scripts/trellis-check.sh` — still green against the real repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)