### PR TITLE
init: scaffold .vine/README.md orientation doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Thumbs.db
 # Track context overlays and resolved projects for contributor context
 # Ignore active work, profile, and ephemeral state
 .vine/*
+!.vine/README.md
 !.vine/context/
 !.vine/projects/
 !.vine/scripts/

--- a/.vine/README.md
+++ b/.vine/README.md
@@ -1,0 +1,88 @@
+# Using VINE in this repo
+
+This directory holds VINE's working state for **VINE Framework**. VINE is a pure-markdown,
+AI-assisted development framework: features flow through phases — **verify → inquire → navigate
+→ evolve** (plus lightweight **pair** for small changes) — and each phase reads shared context
+from here and writes its artifacts back.
+
+New here? Run `/vine:help` for the full command list, or `/vine:status` to see where the current
+feature stands.
+
+## What lives under `.vine/`
+
+| Path | What it is |
+|------|------------|
+| `context/shared.md` | Repo-wide overlay, loaded by every phase |
+| `context/<phase>.md` | Per-phase overlays — `verify.md`, `inquire.md`, `navigate.md`, `evolve.md`, `pair.md` |
+| `context/shared.local.md` | Your personal overlay layer (optional, gitignored) |
+| `projects/<domain>/<feature-slug>/` | Per-feature artifacts: CONTEXT → SPEC → NAVIGATION → EVOLUTION, plus PROJECT-MAP |
+| `PROFILE.md` | Your per-domain expertise, used to tune explanation depth (gitignored) |
+| `scripts/` | Native hook scripts (e.g. `journal-check.sh`) |
+| `ACTIVE`, `projects/**/PAUSE.md` | Ephemeral session state (gitignored) |
+
+`references/STATE.md` in the repo root is the **authoritative** contract for every artifact's
+format and lifecycle. Treat this table as a map; consult STATE.md for the details.
+
+## Context overlays
+
+Each phase composes its context from up to three layers:
+
+1. **`shared.md`** — repo-wide context every phase loads (conventions, tooling notes, the
+   collaboration stance, the validation contract).
+2. **`<phase>.md`** — guidance only one phase needs (which agents `navigate` invokes, what
+   `verify` should always explore). These exist only where there's something to add.
+3. **`shared.local.md`** — your personal layer. Gitignored; absent it, nothing changes.
+
+### Overlay precedence
+
+The layers resolve as **flat personal-wins with policy carve-outs** — like Claude's own
+settings, where local overrides project except for an immutable policy ceiling:
+
+- **Preference content** (every unmarked section) is personal-overridable: where
+  `shared.local.md` and `shared.md` conflict, your personal layer wins.
+- **Policy content** is immutable from the personal layer. A section marked
+  `<!-- class: policy -->` directly under its heading (e.g. **Team Context**, **CI/CD**) always
+  wins; `shared.local.md` can't weaken or replace it.
+
+Only policy-class sections carry the marker — unmarked means preference.
+
+## The `## Validation` block
+
+`shared.md` may carry an optional `## Validation` section: a fenced YAML block that declares how
+this repo's checks run, so verification doesn't have to guess.
+
+```yaml
+lint: <command>          # linter / formatter
+typecheck: <command>     # static type check
+test: <command>          # scoped / per-file tests
+test-all: <command>      # full suite
+build: <command>         # build / compile check
+extra:                   # anything else
+  - <command>
+```
+
+Every key is **optional** — declare only the checks this repo has. The `vine:verify`
+verification agent and the `navigate` / `evolve` / `pair` phases read this block to run the right
+checks; with no block (or missing keys) they fall back to inferring commands from package scripts
+and config. Full schema: `references/STATE.md`.
+
+## Customizing VINE for this repo
+
+- **Edit the overlays.** `shared.md` and the per-phase files are plain markdown — change them to
+  teach VINE this repo's conventions, tools, and gotchas. Re-running `/vine:init` in upgrade mode
+  folds in newly discovered tooling without clobbering your edits.
+- **Add per-phase guidance.** Create or extend `context/<phase>.md` to give one phase context the
+  others don't need.
+- **Keep personal tweaks local.** Drop preferences you don't want to commit into
+  `context/shared.local.md` — it overrides preference sections but never policy ones.
+
+### Plugins & team distribution (forward-looking)
+
+Packaging VINE as a Claude Code plugin and distributing shared team overlays are on the roadmap,
+not yet shipped. Track progress here:
+
+- [VINE #57 — Claude Code plugin: packaging + team-overlay distribution](https://github.com/moduloMoments/VINE/issues/57)
+- [VINE #52 — Team layer](https://github.com/moduloMoments/VINE/issues/52)
+
+Until those land, share overlays the manual way: commit the files under `.vine/context/` you want
+your team to share, and keep personal-only tweaks in the gitignored `.local` layer.

--- a/commands/vine/init.md
+++ b/commands/vine/init.md
@@ -23,11 +23,13 @@ team patterns, then scaffolding `.vine/context/` with project-specific templates
 1. Discovers what's available in the repo (tools, agents, skills, commands, CI, test patterns)
 2. Asks the engineer about team context that can't be derived from code
 3. Generates `.vine/context/shared.md` and per-phase overlay files pre-filled with relevant context
-4. Optionally adds `.vine/` to `.gitignore`
-5. Introduces the engineer profile (builds organically through vine:verify)
-6. Offers the native hook scaffold — mechanical enforcement of the journal-before-commit
+4. Scaffolds `.vine/README.md` — a tracked, human/agent-facing orientation doc for using VINE in
+   this repo (written for fresh repos; offered, not forced, in upgrade mode)
+5. Optionally adds `.vine/` to `.gitignore` (keeping `.vine/README.md` tracked)
+6. Introduces the engineer profile (builds organically through vine:verify)
+7. Offers the native hook scaffold — mechanical enforcement of the journal-before-commit
    guarantee, declinable
-7. In upgrade mode, offers single-homing of CLAUDE.md/shared.md duplicates per the
+8. In upgrade mode, offers single-homing of CLAUDE.md/shared.md duplicates per the
    Knowledge Boundary rule — declinable
 
 ## Step 1: Discover Repo Capabilities
@@ -195,22 +197,147 @@ and agents to suggest wiring into overlays for next time
 **pair.md** — Preferred test commands for quick changes, lint/format requirements,
 commit message conventions for small fixes
 
-## Step 4: Create Projects Directory
+## Step 4: Scaffold the .vine/README.md Orientation Doc
+
+Write `.vine/README.md` — a tracked, human/agent-facing doc that orients anyone opening this
+repo on how to *use* VINE inside it (what lives under `.vine/`, how overlays compose, how to
+customize). It is distinct from the overlays: overlays configure VINE's behavior; this README
+explains it.
+
+Write it from the template below, filling `[Project Name]` and `[date]`. The template points at
+`references/STATE.md` for the authoritative structure rather than duplicating it — keep it that
+way so the README can't drift from the contract.
+
+**Fresh repos:** write the file. **Upgrade mode** (existing `.vine/context/`): don't write it
+here — Step 8 offers it, declinable. Either way, Step 6 keeps `.vine/README.md` tracked even when
+the rest of `.vine/` is gitignored.
+
+The outer four-backtick fence below only delimits the template for *this* doc; write the inner
+content (starting at `# Using VINE in this repo`) to `.vine/README.md`.
+
+````markdown
+# Using VINE in this repo
+
+This directory holds VINE's working state for **[Project Name]**. VINE is a pure-markdown,
+AI-assisted development framework: features flow through phases — **verify → inquire → navigate
+→ evolve** (plus lightweight **pair** for small changes) — and each phase reads shared context
+from here and writes its artifacts back.
+
+New here? Run `/vine:help` for the full command list, or `/vine:status` to see where the current
+feature stands.
+
+## What lives under `.vine/`
+
+| Path | What it is |
+|------|------------|
+| `context/shared.md` | Repo-wide overlay, loaded by every phase |
+| `context/<phase>.md` | Per-phase overlays — `verify.md`, `inquire.md`, `navigate.md`, `evolve.md`, `pair.md` |
+| `context/shared.local.md` | Your personal overlay layer (optional, gitignored) |
+| `projects/<domain>/<feature-slug>/` | Per-feature artifacts: CONTEXT → SPEC → NAVIGATION → EVOLUTION, plus PROJECT-MAP |
+| `PROFILE.md` | Your per-domain expertise, used to tune explanation depth (gitignored) |
+| `scripts/` | Native hook scripts (e.g. `journal-check.sh`) |
+| `ACTIVE`, `projects/**/PAUSE.md` | Ephemeral session state (gitignored) |
+
+`references/STATE.md` in the repo root is the **authoritative** contract for every artifact's
+format and lifecycle. Treat this table as a map; consult STATE.md for the details.
+
+## Context overlays
+
+Each phase composes its context from up to three layers:
+
+1. **`shared.md`** — repo-wide context every phase loads (conventions, tooling notes, the
+   collaboration stance, the validation contract).
+2. **`<phase>.md`** — guidance only one phase needs (which agents `navigate` invokes, what
+   `verify` should always explore). These exist only where there's something to add.
+3. **`shared.local.md`** — your personal layer. Gitignored; absent it, nothing changes.
+
+### Overlay precedence
+
+The layers resolve as **flat personal-wins with policy carve-outs** — like Claude's own
+settings, where local overrides project except for an immutable policy ceiling:
+
+- **Preference content** (every unmarked section) is personal-overridable: where
+  `shared.local.md` and `shared.md` conflict, your personal layer wins.
+- **Policy content** is immutable from the personal layer. A section marked
+  `<!-- class: policy -->` directly under its heading (e.g. **Team Context**, **CI/CD**) always
+  wins; `shared.local.md` can't weaken or replace it.
+
+Only policy-class sections carry the marker — unmarked means preference.
+
+## The `## Validation` block
+
+`shared.md` may carry an optional `## Validation` section: a fenced YAML block that declares how
+this repo's checks run, so verification doesn't have to guess.
+
+```yaml
+lint: <command>          # linter / formatter
+typecheck: <command>     # static type check
+test: <command>          # scoped / per-file tests
+test-all: <command>      # full suite
+build: <command>         # build / compile check
+extra:                   # anything else
+  - <command>
+```
+
+Every key is **optional** — declare only the checks this repo has. The `vine:verify`
+verification agent and the `navigate` / `evolve` / `pair` phases read this block to run the right
+checks; with no block (or missing keys) they fall back to inferring commands from package scripts
+and config. Full schema: `references/STATE.md`.
+
+## Customizing VINE for this repo
+
+- **Edit the overlays.** `shared.md` and the per-phase files are plain markdown — change them to
+  teach VINE this repo's conventions, tools, and gotchas. Re-running `/vine:init` in upgrade mode
+  folds in newly discovered tooling without clobbering your edits.
+- **Add per-phase guidance.** Create or extend `context/<phase>.md` to give one phase context the
+  others don't need.
+- **Keep personal tweaks local.** Drop preferences you don't want to commit into
+  `context/shared.local.md` — it overrides preference sections but never policy ones.
+
+### Plugins & team distribution (forward-looking)
+
+Packaging VINE as a Claude Code plugin and distributing shared team overlays are on the roadmap,
+not yet shipped. Track progress here:
+
+- [VINE #57 — Claude Code plugin: packaging + team-overlay distribution](https://github.com/moduloMoments/VINE/issues/57)
+- [VINE #52 — Team layer](https://github.com/moduloMoments/VINE/issues/52)
+
+Until those land, share overlays the manual way: commit the files under `.vine/context/` you want
+your team to share, and keep personal-only tweaks in the gitignored `.local` layer.
+````
+
+## Step 5: Create Projects Directory
 
 Create `.vine/projects/` — the directory where all VINE project artifacts live. This keeps
 project state (CONTEXT.md, SPEC.md, NAVIGATION.md, etc.) separate from configuration
 (context/, PROFILE.md). All VINE phases read and write project artifacts under this directory.
 
-## Step 5: Gitignore
+## Step 6: Gitignore
 
-Check if `.vine/` is already in `.gitignore` or the user's global gitignore. If neither,
-add `.vine/` to the project's `.gitignore` automatically. VINE artifacts are workflow state,
-not repo artifacts — they shouldn't be committed by default.
+VINE's working state (active projects, profile, ephemera) is workflow state, not repo artifacts,
+and shouldn't be committed by default — but `.vine/README.md` is the one exception: it's a
+tracked orientation doc meant to be shared. So the ignore rule must exclude `.vine/` **while
+keeping the README tracked**.
 
-If the engineer explicitly wants to commit VINE artifacts (e.g., for team sharing), they
-can `git add -f .vine/` selectively.
+Check whether `.vine/` is already covered by `.gitignore` or the user's global gitignore, then:
 
-## Step 6: Introduce Engineer Profile
+- **Not ignored yet:** add this block to the project's `.gitignore`:
+  ```
+  .vine/*
+  !.vine/README.md
+  ```
+  Use `.vine/*` (ignore the directory's *contents*), not `.vine/` (ignore the directory itself) —
+  git can't re-include a file whose parent directory is wholly excluded, so a bare `.vine/` would
+  silently keep `.vine/README.md` ignored despite the negation.
+- **Already ignored as a whole directory** (`.vine/` on its own line): change it to `.vine/*` and
+  add `!.vine/README.md` directly after, so the negation can take effect.
+- **Already ignored with selective negations** (e.g. `.vine/*` plus `!.vine/context/`): just
+  ensure `!.vine/README.md` is present; add it if missing.
+
+If the engineer wants to commit more VINE artifacts (e.g., overlays for team sharing), they can
+add further negations or `git add -f .vine/<path>` selectively.
+
+## Step 7: Introduce Engineer Profile
 
 After generating overlays, briefly mention the engineer profile to the engineer:
 
@@ -225,7 +352,7 @@ as the engineer works in different domains. This step is purely informational.
 If `.vine/PROFILE.md` already exists (e.g., from a previous init or manual creation), skip
 this message entirely.
 
-## Step 7: Upgrade Existing Projects
+## Step 8: Upgrade Existing Projects
 
 ### Legacy Directory Migration
 
@@ -279,6 +406,15 @@ If `.vine/context/` already exists (from a previous `/vine:init` or manual setup
    - New required sections added to shared.md
 5. Merge accepted changes into existing overlay files — don't overwrite custom content the
    engineer has added
+6. If `.vine/README.md` is missing, offer to scaffold it from the Step 4 template via
+   `AskUserQuestion` (`multiSelect: false`, 2 options):
+   - **"Add .vine/README.md (Recommended)"** — description: "Write the orientation doc covering
+     overlays, precedence, and the validation block"
+   - **"Not now"** — description: "Skip it — nothing changes on disk"
+
+   **Declining is a no-op** — no file written, and the offer repeats on the next `/vine:init`.
+   If the README already exists, skip this silently. When writing it, also apply the Step 6
+   gitignore check so the new file is tracked.
 
 This makes upgrading after installing new skills, agents, or commands a one-command operation.
 
@@ -360,6 +496,7 @@ or upgrade):
    - .vine/context/navigate.md (if applicable)
    - .vine/context/evolve.md (if applicable)
    - .vine/context/pair.md (if applicable)
+   - .vine/README.md (orientation doc — tracked; offered, not written, in upgrade mode)
    - .vine/projects/ (project artifacts directory)
    - .claude/settings.json hooks (if the scaffold offer was accepted)
 

--- a/commands/vine/init.md
+++ b/commands/vine/init.md
@@ -319,20 +319,21 @@ and shouldn't be committed by default — but `.vine/README.md` is the one excep
 tracked orientation doc meant to be shared. So the ignore rule must exclude `.vine/` **while
 keeping the README tracked**.
 
-Check whether `.vine/` is already covered by `.gitignore` or the user's global gitignore, then:
+The target end-state is always the same two lines (alongside any other `.vine` negations):
 
-- **Not ignored yet:** add this block to the project's `.gitignore`:
-  ```
-  .vine/*
-  !.vine/README.md
-  ```
-  Use `.vine/*` (ignore the directory's *contents*), not `.vine/` (ignore the directory itself) —
-  git can't re-include a file whose parent directory is wholly excluded, so a bare `.vine/` would
-  silently keep `.vine/README.md` ignored despite the negation.
-- **Already ignored as a whole directory** (`.vine/` on its own line): change it to `.vine/*` and
-  add `!.vine/README.md` directly after, so the negation can take effect.
-- **Already ignored with selective negations** (e.g. `.vine/*` plus `!.vine/context/`): just
-  ensure `!.vine/README.md` is present; add it if missing.
+```
+.vine/*
+!.vine/README.md
+```
+
+Use `.vine/*` (ignore the directory's *contents*), not bare `.vine/` (ignore the directory
+itself) — git can't re-include a file whose parent directory is wholly excluded, so a negation
+under a bare `.vine/` silently does nothing. Reconcile whatever's already in `.gitignore` (or the
+user's global gitignore) toward that end-state:
+
+- **No `.vine` ignore yet:** add the two lines.
+- **Already ignored:** normalize a bare `.vine/` to `.vine/*`, then ensure `!.vine/README.md`
+  follows it (add it if missing). Leave any existing negations like `!.vine/context/` in place.
 
 If the engineer wants to commit more VINE artifacts (e.g., overlays for team sharing), they can
 add further negations or `git add -f .vine/<path>` selectively.

--- a/references/STATE.md
+++ b/references/STATE.md
@@ -331,7 +331,7 @@ Unlike per-feature artifacts, PROFILE.md lives at `.vine/PROFILE.md` (repo root,
 
 **Lifecycle:**
 
-1. **Introduced** at vine:init (Step 5) — informational only. Tells the engineer the profile exists and will build through vine:verify. No domain rating at init time.
+1. **Introduced** at vine:init (Step 7) — informational only. Tells the engineer the profile exists and will build through vine:verify. No domain rating at init time.
 2. **Re-prompted** at vine:verify start — if the current feature's domain isn't in the profile, offers to add it.
 3. **Read** by vine:verify, vine:inquire, and vine:navigate — sets a one-sentence depth hint for the session. If no profile exists or the domain isn't listed, commands behave exactly as today.
 4. **Updated** by vine:evolve — proposes domain level changes and growth log entries based on the completed cycle. Engineer approves via AskUserQuestion. Evolve also suggests Claude memory entries and CLAUDE.md lines for general preferences discovered during the cycle.
@@ -345,6 +345,14 @@ Unlike per-feature artifacts, PROFILE.md lives at `.vine/PROFILE.md` (repo root,
 - **Fully opt-in.** Every command works identically without PROFILE.md. No errors, no warnings, no degraded behavior.
 - **Domain matching is exact.** The domain in PROFILE.md must match the `.vine/projects/<domain>/` namespace exactly. No fuzzy matching.
 - **Engineer controls updates.** Evolve suggests changes; the engineer approves or modifies them. VINE never silently updates the profile.
+
+### README.md (seeded by vine:init)
+
+`.vine/README.md` is a human/agent-facing orientation doc explaining how to *use* VINE inside this repo — what lives under `.vine/`, how context overlays compose (precedence, the `.local` layer), the optional `## Validation` block, and how to customize VINE for the repo. It is the one tracked file under `.vine/` by default (init's gitignore step adds a `!.vine/README.md` negation); everything else is workflow state or gitignored.
+
+Unlike the overlays, the README configures nothing — overlays steer VINE's behavior, the README documents it. It points back to this file (STATE.md) for the authoritative artifact structure rather than duplicating it, so it can't drift from the contract.
+
+**Lifecycle:** written from a template at vine:init (Step 4) for fresh repos; **offered, declinable** in upgrade mode (Step 8) when absent. Declining changes nothing on disk. Like every other scaffold, VINE works identically whether or not the README is present.
 
 ## Knowledge Boundary
 


### PR DESCRIPTION
## What

`vine:init` now scaffolds `.vine/README.md` — a tracked doc that orients a human or agent on how to *use* VINE inside their repo: what lives under `.vine/`, how context overlays compose (precedence + the personal `.local` layer), the optional `## Validation` block, and how to customize VINE (overlays, per-phase guidance, plugins/distribution). Fresh repos get it written; upgrade mode offers it (declinable). The gitignore step keeps it tracked, STATE.md documents the new artifact, and this repo ships its own copy.

## Why

`.vine/` had no in-repo explanation of itself — newcomers had to reverse-engineer overlays, precedence, and the validation contract from the command files. This gives every VINE repo a self-describing entry point, built on the overlay model from #94. Related (not closed): #57 (plugin / team-overlay distribution) and #52 (team layer) — the README links both as forward-looking rather than promising them.

## How to test

1. Run `/vine:init` on a fresh repo → `.vine/README.md` is written and `.gitignore` keeps it tracked (`.vine/*` + `!.vine/README.md`).
2. Run `/vine:init` where `.vine/context/` already exists → you're offered the README; declining changes nothing on disk.
3. `sh .vine/scripts/trellis-check.sh` → 11/11 commands pass, 8 anchors resolve.

## Checklist

- [x] I've tested this in an actual VINE cycle (trellis green; tracking + backward-compat verified)
- [x] Changes are focused on a single concern
- [x] Any new behavior is documented in the README or command file

🤖 Generated with [Claude Code](https://claude.com/claude-code)