### PR TITLE
Routing gate: ROUTE.md record + navigate-head eligibility gate

### DIFF
--- a/.vine/projects/workflow/routing-foundation/NAVIGATION.md
+++ b/.vine/projects/workflow/routing-foundation/NAVIGATION.md
@@ -338,7 +338,7 @@ PROJECT-MAP pointer.
 
 ### Slice 9: PROJECT-MAP Route table as derived pointer — Complete
 - **Started**: 2026-06-14 17:40
-- **Commit**: pending
+- **Commit**: 9f0f8df
 - **Approach taken**: Added a `### Route <!-- optional -->` table to the PROJECT-MAP.md template
   in `references/STATE.md` (after Milestones): columns `Scope | Route | Gate record`, with the
   Gate-record cell linking to `./ROUTE.md` and Route using the controlled vocabulary

--- a/.vine/projects/workflow/routing-foundation/NAVIGATION.md
+++ b/.vine/projects/workflow/routing-foundation/NAVIGATION.md
@@ -306,7 +306,7 @@ PROJECT-MAP pointer.
 
 ### Slice 8: Inquire route preview (non-binding) — Complete
 - **Started**: 2026-06-14 17:36
-- **Commit**: pending
+- **Commit**: 949145f
 - **Approach taken**: Added a `🧭 Route preview (non-binding):` line to inquire.md's completion
   block, placed after the `🔄 /clear` recommendation and before the `🌱 retro` — modeled on
   verify.md's `🧭 Navigate gearing note:` line. It previews the likely route by reading the
@@ -335,3 +335,55 @@ PROJECT-MAP pointer.
   - Claude → Engineer: The spec's cross-reference to "inquire's gearing preview" was off by one
     command (it's verify's) — caught by grepping for `gear` in inquire.md before assuming. Cheap
     direct check beats trusting a spec's incidental file note (shared.md: diagnosis-unverified).
+
+### Slice 9: PROJECT-MAP Route table as derived pointer — Complete
+- **Started**: 2026-06-14 17:40
+- **Commit**: pending
+- **Approach taken**: Added a `### Route <!-- optional -->` table to the PROJECT-MAP.md template
+  in `references/STATE.md` (after Milestones): columns `Scope | Route | Gate record`, with the
+  Gate-record cell linking to `./ROUTE.md` and Route using the controlled vocabulary
+  (interactive | headless | headless-reentry). Added a "Route table is a derived pointer" design
+  constraint and folded the Route row into the existing PROJECT-MAP derived-view bullet in the
+  Source of Truth section (when it disagrees with ROUTE.md, ROUTE.md wins) and into the
+  navigate-updates lifecycle note. Added a "Point PROJECT-MAP.md at it" instruction to navigate's
+  gate section — when navigate writes ROUTE.md and PROJECT-MAP.md exists, it adds/updates the
+  Route row; skips silently when PROJECT-MAP.md is absent.
+- **Deviations from spec**: None. Kept columns to `Scope | Route | Gate record` (the derived
+  pointer Slice 9 needs); the spike's fuller `Actor`/`Outcome` columns are headless-execution
+  concepts that Slice 13 (#90 journal schema) owns — not added prematurely here.
+- **Validation**: pass — `sh .vine/scripts/trellis-check.sh` 11/11 + 8/8 anchors; the new
+  template heading carries an `<!-- optional -->` marker (no unmarked-heading warning); the real
+  routing-foundation PROJECT-MAP.md has no Route table (this feature ran interactively — gate is
+  a no-op, no ROUTE.md), exercising the graceful-absence path.
+- **Decisions made during implementation**:
+  - Three columns now, not the spike's five — Actor/Outcome are Phase-3/Slice-13 territory.
+    (decided by: claude)
+  - Wired the row-write into navigate's gate section (where ROUTE.md is written) rather than a
+    separate step, so the pointer and its target are written together. (decided by: claude)
+- **Acceptance criteria**:
+  - [x] The Route table links to ROUTE.md and holds no authoritative state (derived view)
+  - [x] Reconstructable from ROUTE.md
+  - [x] The table is optional/graceful when absent
+- **Engineer feedback incorporated**: None this slice (free climb).
+- **Learnings**:
+  - Engineer → Claude: None specific to this slice.
+  - Claude → Engineer: A derived view earns its keep only if it adds no new state — keeping the
+    Route table to three columns (and deferring Actor/Outcome to the slice that owns the
+    underlying journal schema) keeps it a pure pointer, not a second writer.
+
+### Remaining Work
+- **Incomplete slices**: All Phase 2 slices (6-9) complete. Phase 3 (Slices 10-13: Headless
+  Contract & Journaling) and Phase 4 (Slices 14-17: Docs, Reviewer & Trellis) remain.
+- **Blockers encountered**: None.
+- **Handoff context**:
+  - **Slice 17 discovered item**: CLAUDE.md `## State Artifact Chain` line still reads
+    `CONTEXT → SPEC → NAVIGATION → EVOLUTION` (omits ROUTE.md). Fold the ROUTE.md insertion into
+    Slice 17's cross-reference sweep alongside the count updates. (Slice 6 stayed scoped to
+    STATE.md per the spec's file mapping.)
+  - **Spec note for Phase 3**: the spec's Slice 8 file hint ("alongside the existing gearing
+    preview" in inquire) is off — the gearing preview lives in verify.md. No action needed;
+    recorded so it isn't re-investigated.
+  - **Phase 3 builds on this**: ROUTE.md format (Slice 6), the navigate-head gate + verdict
+    (Slice 7), and the Route table (Slice 9) are the substrate the headless contract (Slice 12)
+    and #90 journal schema (Slice 13) consume. The headless *entry signal* was deliberately left
+    vague in navigate's gate section — Slice 12 defines it.

--- a/.vine/projects/workflow/routing-foundation/NAVIGATION.md
+++ b/.vine/projects/workflow/routing-foundation/NAVIGATION.md
@@ -200,3 +200,55 @@ predated main's #92). Authoring stays interactive under engineer review.
   - Claude → Engineer: A slice that edits both a repo's live overlay AND the init template needs
     to touch *both* in the same breath — editing shared.md without the template is the exact
     drift class the boundary verification caught.
+
+## Phase 2: Eligibility Gate & Route Record (Slices 6-9)
+
+Resumed 2026-06-14 17:20 in free-climb gearing (engineer choice; profile confident/workflow).
+Branch synced to origin/main (the #94 squash-merge) before starting. Building the route
+decision: the gate record (ROUTE.md), the navigate-head gate, the inquire preview, and the
+PROJECT-MAP pointer.
+
+### Slice 6: ROUTE.md artifact format in STATE.md — Complete
+- **Started**: 2026-06-14 17:25
+- **Commit**: pending
+- **Approach taken**: Added a `### ROUTE.md` State File section to `references/STATE.md`, placed
+  in chain order between SPEC.md and NAVIGATION.md (the route is decided before slices execute).
+  The template carries the six required pieces — Verdict (controlled `interactive |
+  headless | headless-reentry` route + `mechanism:` token), Eligibility Legs (the four-leg #54
+  predicate as a checklist), Constraints, Allowlist, Validation Baseline, Input Basis (HEAD SHA +
+  in-flight set) — plus an optional Decay note and a `## Computed at:` stamp. Reused the spike's
+  validated vocabulary (Route table was its best-performing scaffold; verdict + constraints +
+  allowlist + validation baseline is the convergent finding from EVOLUTION.md:29). Added ROUTE.md
+  to the Source of Truth table (authoritative for the route decision; PROJECT-MAP Route table is
+  its derived view — wired in Slice 9), to the Committing Artifacts artifact list, and as a new
+  "Navigate head" commit-point row. Documented graceful absence and tracked-travel (lives under
+  the already-negated `!.vine/projects/`, so no `.gitignore` change needed).
+- **Deviations from spec**: None.
+- **Validation**: pass — `sh .vine/scripts/trellis-check.sh` 11/11 commands + 8/8 cross-reference
+  anchor pairs (the two new internal links — `#source-of-truth-vs-derived-views`,
+  `#committing-artifacts` — resolve to existing headers). Structural check: all six required
+  fields present with `<!-- required -->` markers; Decay carries `<!-- optional -->`. No
+  `commands/vine/` files touched, so the trellis command-commit gate is not involved.
+- **Decisions made during implementation**:
+  - Placed ROUTE.md in chain order between SPEC.md and NAVIGATION.md but labeled it "produced by
+    vine:navigate at head, previewed by vine:inquire" — the artifact's logical position (route
+    decided before implementation) differs from its writer (navigate). (decided by: claude)
+  - Verdict uses the spike's controlled route vocabulary + `mechanism:` token rather than a free
+    field, aligning ahead of the #90 schema work in Slice 13. (decided by: claude)
+  - Kept Slice 6 scoped to `references/STATE.md` per the SPEC's file mapping. CLAUDE.md's
+    "State Artifact Chain" line still reads CONTEXT → SPEC → NAVIGATION → EVOLUTION (no ROUTE);
+    that cross-reference is Slice 17's sweep ("cross-references consistent across CLAUDE.md …").
+    Flagged here so Slice 17 doesn't miss it. (decided by: claude)
+- **Discovered item (for Slice 17)**: CLAUDE.md `## State Artifact Chain` line omits ROUTE.md;
+  fold into the Slice 17 cross-reference sweep alongside the count updates.
+- **Acceptance criteria**:
+  - [x] Format carries verdict + constraints + allowlist + validation baseline + computed-at +
+        input basis (HEAD SHA, in-flight set)
+  - [x] Section headings carry required/optional markers
+  - [x] The record is documented as travelling tracked with the feature
+- **Engineer feedback incorporated**: Gearing set to free climb up front.
+- **Learnings**:
+  - Engineer → Claude: None specific to this slice.
+  - Claude → Engineer: Reusing the spike's already-validated scaffold vocabulary (route verdict,
+    `mechanism:` token, the verdict+constraints+allowlist+baseline quartet) made the format a
+    promotion of proven shapes rather than a fresh design — the de-risking the spike paid for.

--- a/.vine/projects/workflow/routing-foundation/NAVIGATION.md
+++ b/.vine/projects/workflow/routing-foundation/NAVIGATION.md
@@ -255,7 +255,7 @@ PROJECT-MAP pointer.
 
 ### Slice 7: Navigate-head gate evaluation + ROUTE.md write + re-eval — Complete
 - **Started**: 2026-06-14 17:30
-- **Commit**: pending
+- **Commit**: dc60e70
 - **Approach taken**: Added a `### Route the Work — Eligibility Gate (runs once, at head)`
   section to `commands/vine/navigate.md`, placed between step 2 (Create a Feature Branch) and
   step 3 (Implement One Slice at a Time) — navigate-head, after setup, before the slice loop.
@@ -303,3 +303,35 @@ PROJECT-MAP pointer.
     per-slice loop untouched, so the diff *shows* the interactive flow is unchanged rather than
     asserting it. The unnumbered-section choice was the same instinct: change nothing that's
     referenced by position.
+
+### Slice 8: Inquire route preview (non-binding) — Complete
+- **Started**: 2026-06-14 17:36
+- **Commit**: pending
+- **Approach taken**: Added a `🧭 Route preview (non-binding):` line to inquire.md's completion
+  block, placed after the `🔄 /clear` recommendation and before the `🌱 retro` — modeled on
+  verify.md's `🧭 Navigate gearing note:` line. It previews the likely route by reading the
+  four-leg predicate against the spec as written, and states explicitly that it does not write
+  ROUTE.md and that navigate's head gate makes the binding call by re-evaluating volatile legs.
+- **Deviations from spec**: None against the ACs. Note: the spec's file hint says "alongside the
+  existing gearing preview" in inquire, but the gearing preview actually lives in verify.md's
+  completion block (`🧭 Navigate gearing note:`), not inquire's. I modeled the route preview on
+  that verify pattern and placed it in inquire's completion block as the ACs require — the
+  intent (a non-binding preview mirroring the gearing-note style) is met. Not a spec deviation
+  to annotate: the phrase is descriptive context, not an acceptance criterion.
+- **Validation**: pass — `sh .vine/scripts/trellis-check.sh` 11/11 + 8/8 anchors; grep confirms
+  the non-binding language ("does not write ROUTE.md", "makes the binding call").
+- **Decisions made during implementation**:
+  - Placed the preview before the retro (end of block), matching verify's placement of its
+    `🧭` note at the block tail. (decided by: claude)
+  - Phrased it as a bracketed instruction (like the gearing note) so inquire fills it from the
+    actual spec at runtime, rather than hardcoding a verdict. (decided by: claude)
+- **Acceptance criteria**:
+  - [x] The preview is explicitly non-binding
+  - [x] It does not write ROUTE.md
+  - [x] Navigate's evaluation remains authoritative
+- **Engineer feedback incorporated**: None this slice (free climb).
+- **Learnings**:
+  - Engineer → Claude: None specific to this slice.
+  - Claude → Engineer: The spec's cross-reference to "inquire's gearing preview" was off by one
+    command (it's verify's) — caught by grepping for `gear` in inquire.md before assuming. Cheap
+    direct check beats trusting a spec's incidental file note (shared.md: diagnosis-unverified).

--- a/.vine/projects/workflow/routing-foundation/NAVIGATION.md
+++ b/.vine/projects/workflow/routing-foundation/NAVIGATION.md
@@ -210,7 +210,7 @@ PROJECT-MAP pointer.
 
 ### Slice 6: ROUTE.md artifact format in STATE.md — Complete
 - **Started**: 2026-06-14 17:25
-- **Commit**: 7271476
+- **Commit**: 172867b
 - **Approach taken**: Added a `### ROUTE.md` State File section to `references/STATE.md`, placed
   in chain order between SPEC.md and NAVIGATION.md (the route is decided before slices execute).
   The template carries the six required pieces — Verdict (controlled `interactive |
@@ -255,7 +255,7 @@ PROJECT-MAP pointer.
 
 ### Slice 7: Navigate-head gate evaluation + ROUTE.md write + re-eval — Complete
 - **Started**: 2026-06-14 17:30
-- **Commit**: dc60e70
+- **Commit**: 92c13ad
 - **Approach taken**: Added a `### Route the Work — Eligibility Gate (runs once, at head)`
   section to `commands/vine/navigate.md`, placed between step 2 (Create a Feature Branch) and
   step 3 (Implement One Slice at a Time) — navigate-head, after setup, before the slice loop.
@@ -306,7 +306,7 @@ PROJECT-MAP pointer.
 
 ### Slice 8: Inquire route preview (non-binding) — Complete
 - **Started**: 2026-06-14 17:36
-- **Commit**: 949145f
+- **Commit**: 766af0c
 - **Approach taken**: Added a `🧭 Route preview (non-binding):` line to inquire.md's completion
   block, placed after the `🔄 /clear` recommendation and before the `🌱 retro` — modeled on
   verify.md's `🧭 Navigate gearing note:` line. It previews the likely route by reading the
@@ -338,7 +338,7 @@ PROJECT-MAP pointer.
 
 ### Slice 9: PROJECT-MAP Route table as derived pointer — Complete
 - **Started**: 2026-06-14 17:40
-- **Commit**: 9f0f8df
+- **Commit**: 42b576a
 - **Approach taken**: Added a `### Route <!-- optional -->` table to the PROJECT-MAP.md template
   in `references/STATE.md` (after Milestones): columns `Scope | Route | Gate record`, with the
   Gate-record cell linking to `./ROUTE.md` and Route using the controlled vocabulary
@@ -387,3 +387,18 @@ PROJECT-MAP pointer.
     (Slice 7), and the Route table (Slice 9) are the substrate the headless contract (Slice 12)
     and #90 journal schema (Slice 13) consume. The headless *entry signal* was deliberately left
     vague in navigate's gate section — Slice 12 defines it.
+
+### Pre-PR Reconciliation (2026-06-16)
+Before opening the Phase 2 PR, rebased the branch `--onto origin/main` to drop the already-
+squash-merged Phase 1 noise (PR #94) and the merge commits, leaving 6 clean Phase 2 commits.
+Reconciled with two PRs that merged to main while Phase 2 was building:
+- **#95 (init scaffolds `.vine/README.md`)** — touched `references/STATE.md` (PROFILE lifecycle
+  step renumber + new `### README.md` section) in regions after my edits; auto-merged cleanly,
+  no overlap with the ROUTE.md / Route-table additions.
+- **#96 (descope bespoke brain → durable-decisions convention)** — added `## Durable Decisions
+  & Gotchas` and `## Reference Legibility` to STATE.md plus a warning-only trellis Check 11
+  (bare `#<n>` in command files). Verified: my command-file issue refs use the `(#54)` form the
+  check accepts and name what each issue is in surrounding prose, so trellis stays green (11/11
+  + 8 anchors) with no Check 11 warnings. No content conflict — #96's sections sit after mine.
+- The slice **Commit** fields above were rebased: Slice 6 `7271476`→`172867b`, Slice 7
+  `dc60e70`→`92c13ad`, Slice 8 `949145f`→`766af0c`, Slice 9 `9f0f8df`→`42b576a`.

--- a/.vine/projects/workflow/routing-foundation/NAVIGATION.md
+++ b/.vine/projects/workflow/routing-foundation/NAVIGATION.md
@@ -210,7 +210,7 @@ PROJECT-MAP pointer.
 
 ### Slice 6: ROUTE.md artifact format in STATE.md — Complete
 - **Started**: 2026-06-14 17:25
-- **Commit**: pending
+- **Commit**: 7271476
 - **Approach taken**: Added a `### ROUTE.md` State File section to `references/STATE.md`, placed
   in chain order between SPEC.md and NAVIGATION.md (the route is decided before slices execute).
   The template carries the six required pieces — Verdict (controlled `interactive |
@@ -252,3 +252,54 @@ PROJECT-MAP pointer.
   - Claude → Engineer: Reusing the spike's already-validated scaffold vocabulary (route verdict,
     `mechanism:` token, the verdict+constraints+allowlist+baseline quartet) made the format a
     promotion of proven shapes rather than a fresh design — the de-risking the spike paid for.
+
+### Slice 7: Navigate-head gate evaluation + ROUTE.md write + re-eval — Complete
+- **Started**: 2026-06-14 17:30
+- **Commit**: pending
+- **Approach taken**: Added a `### Route the Work — Eligibility Gate (runs once, at head)`
+  section to `commands/vine/navigate.md`, placed between step 2 (Create a Feature Branch) and
+  step 3 (Implement One Slice at a Time) — navigate-head, after setup, before the slice loop.
+  The section: (1) frames interactive as the default, never-gated path and the gate as a no-op
+  for ordinary human-driven sessions; (2) runs the real four-leg predicate only when a headless
+  route is on the table (entered headless — Phase 3 — or the engineer asks to delegate);
+  (3) evaluates all four legs against fresh repo state, with blast radius as the reasoned set
+  (Files-likely-touched + requirement-implied files, not raw grep — the spike's F1 root cause);
+  (4) marks independence + blast radius as volatile and mandates recompute (never trust a prior
+  ROUTE.md); (5) writes ROUTE.md with verdict, legs, constraints, allowlist, validation baseline,
+  input basis (`git rev-parse --short HEAD` + in-flight set), and the computed-at stamp;
+  (6) handles resume (recompute volatile legs, rewrite stamp) and graceful absence.
+- **Deviations from spec**: None.
+- **Validation**: pass — `/trellis` (via `sh .vine/scripts/trellis-check.sh`) 11/11 commands +
+  8/8 cross-reference anchors; `.vine/.trellis-ok` stamp written `status: pass` 17:33 (the commit
+  ticket for this command-file change). Frontmatter intact (4 fields). The new section is
+  unnumbered, so no step renumbering and no broken `step N` cross-references.
+- **Decisions made during implementation**:
+  - Inserted the gate as an **unnumbered** `###` section rather than a new numbered step 3.
+    Renumbering would have rippled through navigate.md (`step 3b/3c/3d`, `step 4`, `step 6`,
+    `step 8`) and `references/STATE.md` (`step 4c`, `step 6`, `step 8` pointers) — the exact
+    rename-without-updating-references drift class trellis Check 10 exists to catch. Unnumbered
+    keeps every cross-reference valid and signals "runs once at head," distinct from the
+    per-slice loop. (decided by: claude)
+  - Made the interactive path the explicit default and the gate a no-op for it — the AC's
+    "no change to today's interactive flow" is satisfied by *not touching* the per-slice loop
+    at all; the gate only ever adds the headless option, never gates interactive. (decided by:
+    claude)
+  - Kept the headless *entry signal* deliberately vague ("a later phase") — entry + the
+    headless contract are Slice 12 (Phase 3); Slice 7 only produces the verdict and record.
+    (decided by: claude)
+- **Acceptance criteria**:
+  - [x] Predicate legs (validation contract, slice ACs, independence, bounded blast radius)
+        evaluated against fresh repo state
+  - [x] Bounded blast radius accounts for requirement-implied files, not just occurrence-grep
+  - [x] A missing leg yields headless-ineligible and routes interactively with no change to
+        today's interactive flow
+  - [x] ROUTE.md is written with the stamp and input basis
+  - [x] The step is a no-op for clearly-interactive runs
+- **Engineer feedback incorporated**: None this slice (free climb).
+- **Learnings**:
+  - Engineer → Claude: None specific to this slice.
+  - Claude → Engineer: For the cycle's highest-risk slice, the safest expression of "don't
+    degrade the interactive path" was structural — add a head-only section and leave the entire
+    per-slice loop untouched, so the diff *shows* the interactive flow is unchanged rather than
+    asserting it. The unnumbered-section choice was the same instinct: change nothing that's
+    referenced by position.

--- a/.vine/projects/workflow/routing-foundation/PROJECT-MAP.md
+++ b/.vine/projects/workflow/routing-foundation/PROJECT-MAP.md
@@ -16,6 +16,6 @@
 | Phase | Slices | Status | PR |
 |-------|--------|--------|----|
 | Phase 1: Precedence & Validation Foundation | 1-5 | ✅ Shipped | #94 |
-| Phase 2: Eligibility Gate & Route Record | 6-9 | 🚧 Active | — |
+| Phase 2: Eligibility Gate & Route Record | 6-9 | ✅ Complete | — |
 | Phase 3: Headless Contract & Journaling | 10-13 | ⬜ Pending | — |
 | Phase 4: Docs, Reviewer & Trellis | 14-17 | ⬜ Pending | — |

--- a/.vine/projects/workflow/routing-foundation/PROJECT-MAP.md
+++ b/.vine/projects/workflow/routing-foundation/PROJECT-MAP.md
@@ -16,6 +16,6 @@
 | Phase | Slices | Status | PR |
 |-------|--------|--------|----|
 | Phase 1: Precedence & Validation Foundation | 1-5 | ✅ Shipped | #94 |
-| Phase 2: Eligibility Gate & Route Record | 6-9 | ✅ Complete | — |
+| Phase 2: Eligibility Gate & Route Record | 6-9 | ✅ Complete | #97 |
 | Phase 3: Headless Contract & Journaling | 10-13 | ⬜ Pending | — |
 | Phase 4: Docs, Reviewer & Trellis | 14-17 | ⬜ Pending | — |

--- a/.vine/projects/workflow/routing-foundation/SPEC.md
+++ b/.vine/projects/workflow/routing-foundation/SPEC.md
@@ -188,7 +188,7 @@ repos.
 **Complexity signal**: Medium — the agent is the single consolidated verification surface (#69);
 the fallback must stay intact.
 
-## Phase 2: Eligibility Gate & Route Record (Slices 6-9) ⬜
+## Phase 2: Eligibility Gate & Route Record (Slices 6-9) ✅
 Summary: Build the route decision — the four-leg predicate at navigate-head, the ROUTE.md record,
 the inquire preview, and the PROJECT-MAP pointer.
 Session boundary: After this phase, a scope can be evaluated, routed, and recorded; the headless

--- a/commands/vine/inquire.md
+++ b/commands/vine/inquire.md
@@ -348,6 +348,14 @@ plain chat text, with only the `/vine:navigate` command line in a fenced block:
    Inquire is analytical — navigate needs a tactical, implementation-focused headspace.
    SPEC.md carries everything forward; conversation context doesn't need to.
 
+🧭 Route preview (non-binding): [Based on the four-leg headless predicate read against the
+   spec as written — is there a validation contract, do the slices carry acceptance criteria,
+   do they look independent of in-flight work, is the blast radius bounded — name the likely
+   route, e.g. "Looks headless-eligible — bounded, independent slices with ACs and a validation
+   block" or "Likely interactive — slice 3 overlaps in-flight work / no validation contract yet".
+   This is a preview only, like the gearing note: it does not write ROUTE.md, and navigate's
+   head gate re-evaluates the volatile legs against fresh repo state and makes the binding call.]
+
 🌱 Phase retro:
    - CLAUDE.md suggestion: [any project conventions or decisions worth persisting]
    - Skill suggestion: [any design pattern that could be templated]

--- a/commands/vine/navigate.md
+++ b/commands/vine/navigate.md
@@ -146,6 +146,63 @@ branch, confirm it's the right one for this work:
 If resuming (NAVIGATION.md exists), the engineer is likely already on the right branch — verify
 by checking that the commits recorded in NAVIGATION.md are in the current branch's history.
 
+### Route the Work — Eligibility Gate (runs once, at head)
+
+This runs **once at navigate-head**, after setup and before the first slice — not inside the
+per-slice loop below. It is the authoritative routing gate (#54): it decides whether this scope
+is delivered **interactively** (the default — a human drives, reviewing changes as they land) or
+is **eligible to run headless** (an unattended actor executes, a reviewer checks after), and it
+writes that decision to a durable, reviewer-readable gate record (`ROUTE.md`, format in
+`references/STATE.md`).
+
+**The interactive path is the default and is never gated.** For an ordinary human-driven
+session — the common case — this step is a **no-op**: the route is `interactive`, you write
+nothing or a trivial `interactive` ROUTE.md, and you proceed to step 3 exactly as VINE does
+today. The gate withholds the *headless option* when a leg is missing; it never changes,
+blocks, or degrades the interactive route. (This is the gate-time vs. verification-time
+distinction: a missing leg means "not eligible for headless," not "something is wrong with the
+work.")
+
+**Run the real evaluation only when a headless route is on the table** — the session was entered
+headless (the headless contract and its entry signal land in a later phase), or the engineer
+asks whether this scope could be delegated. When it is, evaluate the four-leg predicate against
+**fresh repo state** (not a stale stamp):
+
+1. **Validation contract exists** — a `## Validation` block is present in `.vine/context/shared.md`
+   (or checks are prose-inferable per `vine-verification`'s fallback). Without a baseline an
+   unattended actor can't self-verify.
+2. **Slice ACs present** — every in-scope SPEC.md slice carries acceptance criteria the actor can
+   check its own work against.
+3. **Independence** — the in-scope slices are independent of in-flight work. Check the live
+   in-flight set fresh (`gh pr list --state open`, `git branch`) for overlap with the allowlist.
+   This leg is **volatile** — it decayed within hours during the cycle-0 spike — so always
+   recompute it here; never trust a prior ROUTE.md's value.
+4. **Bounded blast radius** — the files the work will touch are enumerable. Start from each
+   in-scope slice's `**Files likely touched**`, then **add requirement-implied files** the spec
+   names indirectly — a file an acceptance criterion forces you to touch even though no slice
+   lists it (the spike's F1 root cause: occurrence-grep missed exactly these). Blast radius is
+   the reasoned set, not a raw grep. This leg is volatile too — recompute against current state.
+
+**Verdict.** All four legs hold ⇒ the scope is **headless-eligible** (`Route: headless`). Any
+leg missing ⇒ **`Route: interactive`** (headless-ineligible), and you run interactively with no
+change to today's flow — name the missing leg in the record so the reviewer sees why.
+
+**Write `ROUTE.md`** to the feature directory using the STATE.md format: the verdict, the
+four-leg results, the constraints a headless actor must honor (modify only the allowlist, run the
+validation baseline green before each commit, escalate any decision that needs a human), the
+allowlist, the validation baseline captured from the `## Validation` block, and the **input
+basis** — `HEAD SHA` (`git rev-parse --short HEAD`) and the in-flight set considered — plus the
+`## Computed at:` stamp. The binding decision can't decay because the volatile legs were just
+recomputed; the stamp lets the reviewer compare authorization-time against execution-time state.
+
+**Resuming.** If a ROUTE.md already exists from a prior session, don't read its verdict as
+current — recompute the volatile legs (independence, blast radius) against fresh state and
+rewrite the record with a new stamp. The stale stamp stays visible in git history for drift
+review.
+
+**Backward compatibility.** ROUTE.md is optional with graceful absence; an interactive run need
+not produce one. Nothing about an existing interactive `.vine/` setup changes.
+
 ### 3. Implement One Slice at a Time
 
 For each work slice from SPEC.md (when task tools are available, `TaskUpdate` this slice's

--- a/commands/vine/navigate.md
+++ b/commands/vine/navigate.md
@@ -195,6 +195,12 @@ basis** — `HEAD SHA` (`git rev-parse --short HEAD`) and the in-flight set cons
 `## Computed at:` stamp. The binding decision can't decay because the volatile legs were just
 recomputed; the stamp lets the reviewer compare authorization-time against execution-time state.
 
+**Point PROJECT-MAP.md at it.** If PROJECT-MAP.md exists, add or update its `### Route` table
+(format in `references/STATE.md`) with a row for this scope — the route verdict and a link to
+ROUTE.md in the `Gate record` cell. The table is a **derived pointer**, not a second source of
+truth: it holds no routing state ROUTE.md doesn't, and is always reconstructable from it. If
+PROJECT-MAP.md doesn't exist (older projects), skip silently.
+
 **Resuming.** If a ROUTE.md already exists from a prior session, don't read its verdict as
 current — recompute the volatile legs (independence, blast radius) against fresh state and
 rewrite the record with a new stamp. The stale stamp stays visible in git history for drift

--- a/references/STATE.md
+++ b/references/STATE.md
@@ -337,6 +337,12 @@ The universal progress tracker. Shows at-a-glance where a feature stands in the 
 |-------|--------|--------|----|
 | Phase 1: [Name] | 1-3 | ⬜ Pending | — |
 | Phase 2: [Name] | 4-5 | ⬜ Pending | — |
+
+### Route <!-- optional -->
+
+| Scope | Route | Gate record |
+|-------|-------|-------------|
+| [phase group / slice] | [interactive \| headless \| headless-reentry] | [./ROUTE.md] |
 ```
 
 **Status markers** (three, used in both tables):
@@ -351,7 +357,7 @@ The universal progress tracker. Shows at-a-glance where a feature stands in the 
 
 1. **Created** by `vine:verify` — writes PROJECT-MAP.md alongside CONTEXT.md. VINE Progress table has verify=✅, all others=⬜. No Milestones table yet.
 2. **Updated** by `vine:inquire` — sets inquire→🚧 on start, ✅ on completion. If the engineer confirms multi-PR treatment, adds the Milestones table with all phases as ⬜ Pending.
-3. **Updated** by `vine:navigate` — sets navigate→🚧 on start. At phase group boundaries (multi-PR), updates the completed milestone row to ✅ Shipped and records the PR number if known. Sets navigate→✅ on completion.
+3. **Updated** by `vine:navigate` — sets navigate→🚧 on start. When it writes a ROUTE.md at head, adds/updates the optional Route table row (a derived pointer to ROUTE.md). At phase group boundaries (multi-PR), updates the completed milestone row to ✅ Shipped and records the PR number if known. Sets navigate→✅ on completion.
 4. **Updated** by `vine:evolve` — sets evolve→🚧 on start, ✅ on completion.
 5. **Read** by `vine:resume` — displays VINE Progress and Milestones in the resume summary.
 6. **Read** by `vine:pause` — uses current VINE phase for pause context.
@@ -361,6 +367,7 @@ The universal progress tracker. Shows at-a-glance where a feature stands in the 
 - **Optional.** Every command must work identically without PROJECT-MAP.md. No errors, no warnings. Commands check for its existence before reading or updating.
 - **Created by verify only.** Other phases update it but never create it. If verify didn't create one (e.g., older project), downstream phases skip PROJECT-MAP updates silently.
 - **Milestones table is conditional.** Only added by inquire when the engineer confirms multi-PR treatment. Single-PR features have a VINE Progress table but no Milestones table.
+- **Route table is a derived pointer.** Optional; added by `vine:navigate` when it writes a ROUTE.md (the `Gate record` cell links to it). It holds no authoritative routing state — verdict, legs, constraints, and basis all live in ROUTE.md, and the row is fully reconstructable from it. Absent a ROUTE.md the table is simply omitted; readers treat its absence as "interactive, no headless authorization." Like the rest of PROJECT-MAP, when it disagrees with ROUTE.md, ROUTE.md wins.
 - **Scannable first.** Tables over prose. Short status markers over verbose descriptions. The whole file should be readable in a terminal glance.
 
 ## Per-Repo Artifacts
@@ -513,7 +520,7 @@ Project *state* follows the same single-home discipline the Knowledge Boundary r
 **Derived views** (never authoritative; rebuilt from the sources above):
 
 - **Native tasks** (`TaskCreate`/`TaskUpdate`/`TaskList`, when available) — the ephemeral, in-session **live view** of slice progress. It mirrors NAVIGATION.md: one task per slice in the current phase group, titled by the slice name, status `pending`/`in_progress`/`completed`, ordered to match slice dependencies, with a `(conditional: <condition>)` prefix on conditional slices. It holds the progress *skeleton only* — never the approach, decisions, commits, acceptance criteria, or learnings, which live solely in NAVIGATION.md. `vine:navigate` creates it at session start and updates it at slice transitions; `vine:resume` rebuilds it from NAVIGATION.md (which slices are Complete) plus SPEC.md (the full slice list). **Tasks are rebuilt FROM the journal, never the reverse** — if the session dies nothing is lost, because the live view carries no information the durable artifacts don't already have.
-- **PROJECT-MAP.md** — a **durable** derived view: the scannable phase-level summary (VINE Progress + Milestones). Commands update its rows as a convenience, but every row is reconstructable from the authoritative artifacts (phase status from the artifact chain; slice and milestone status from NAVIGATION.md and SPEC.md). It is a cache for at-a-glance scanning, not a second source of truth — when it disagrees with the journal, the journal wins. This is why its schema stays coarse (phases and phase groups, not slices): pushing slice-level state into it would create a second writer for state the journal already owns.
+- **PROJECT-MAP.md** — a **durable** derived view: the scannable phase-level summary (VINE Progress + Milestones + the optional Route table). Commands update its rows as a convenience, but every row is reconstructable from the authoritative artifacts (phase status from the artifact chain; slice and milestone status from NAVIGATION.md and SPEC.md; the Route row from ROUTE.md). It is a cache for at-a-glance scanning, not a second source of truth — when it disagrees with the journal or ROUTE.md, those win. This is why its schema stays coarse (phases and phase groups, not slices): pushing slice-level state into it would create a second writer for state the journal already owns.
 
 **When task tools are unavailable** there is simply no live view: `vine:navigate`, `vine:resume`, and `vine:status` behave exactly as they do today, reading progress directly from the durable artifacts. Every consumer degrades to the source of truth.
 

--- a/references/STATE.md
+++ b/references/STATE.md
@@ -106,6 +106,74 @@ it on arrival and skip cleanly when the condition isn't met.
 - Dependencies on other work
 ```
 
+### ROUTE.md (produced by vine:navigate at head, previewed by vine:inquire)
+
+The gate record. The durable output of the routing-layer eligibility gate (#54): the verdict on
+how a scope is delivered (interactive vs. headless), the constraints and allowlist a headless
+actor must honor, the validation baseline it runs, and the input basis the decision was computed
+against. It joins the artifact chain between SPEC.md and NAVIGATION.md — the route is decided
+*before* slices execute — and it is the convergent artifact the cycle-0 spike pointed at: the
+record the headless envelope embeds, the reviewer reads, and the PROJECT-MAP Route table points
+at (a derived view — see [Source of Truth vs Derived Views](#source-of-truth-vs-derived-views)).
+
+`vine:inquire` *previews* a likely route in its completion block (non-binding, like its gearing
+preview); `vine:navigate` runs the *authoritative* gate at its head against fresh repo state and
+writes this file. For a clearly-interactive run the gate is a no-op and the route is simply
+`interactive` — the common path is unchanged.
+
+```markdown
+# Route Record: [Feature Name]
+## Feature: .vine/projects/<domain>/<feature-slug>
+## Computed at: [YYYY-MM-DD HH:MM]
+
+### Verdict <!-- required -->
+- **Route**: [interactive | headless | headless-reentry] — `mechanism: [how it runs, or n/a]`
+- **Scope**: [the phase group or slice this record governs]
+- **Rationale**: [one line — why this route was chosen]
+
+### Eligibility Legs <!-- required -->
+The four-leg headless predicate (#54). All four must hold for a headless verdict; a missing leg
+yields `interactive` and never degrades the interactive route (gate-time check, not
+verification-time).
+- [ ] **Validation contract** — a `## Validation` block (or prose-inferable checks) exists
+- [ ] **Slice ACs present** — the in-scope SPEC.md slices carry acceptance criteria
+- [ ] **Independence** — slices are independent of in-flight work [name the conflict if not]
+- [ ] **Bounded blast radius** — files enumerable, including requirement-implied files (not just
+      occurrence-grep — the spike's F1 root cause)
+
+### Constraints <!-- required -->
+- [What the actor must honor — e.g., modify only the allowlist, run the validation baseline green
+  before each commit, escalate human-required decisions per the Decision Delegation policy]
+
+### Allowlist <!-- required -->
+- [Files / paths the headless actor may modify]
+
+### Validation Baseline <!-- required -->
+- [The checks that must pass, captured from the `## Validation` block at compute time — so the
+  reviewer sees the baseline the actor was held to, even if the block later changes]
+
+### Input Basis <!-- required -->
+- **HEAD SHA**: [commit the gate was evaluated against]
+- **In-flight set**: [open PRs / branches weighed for the independence leg, or "none"]
+
+### Decay <!-- optional -->
+- [Freshness note. Volatile legs (independence, blast radius) are re-evaluated at navigate-head,
+  so the *binding* decision can't decay; the reviewer compares this stamp against the execution
+  state to flag authorization-vs-execution drift.]
+```
+
+**Backward compatibility.** ROUTE.md is optional with graceful absence: an interactive run need
+not write one (or writes a trivial `interactive` record), and every reader treats its absence as
+"interactive, no headless authorization." Older features without a ROUTE.md behave exactly as
+they do today.
+
+**Tracking.** Unlike the personal `.local` overlay (gitignored by design), ROUTE.md travels
+**tracked** with the feature — it lives in the feature directory under `.vine/projects/`, which
+`.gitignore` already negates (`!.vine/projects/`), so it ships with the code through history and
+PRs where the reviewer needs it. No `.gitignore` change is required; a repo that gitignores the
+whole artifact chain keeps ROUTE.md local along with the rest (see [Committing
+Artifacts](#committing-artifacts)).
+
 ### NAVIGATION.md (produced by vine:navigate)
 
 The implementation journal. Built incrementally — each slice is appended as it's completed, with a commit per validated slice.
@@ -437,6 +505,7 @@ Project *state* follows the same single-home discipline the Knowledge Boundary r
 | State | Source of truth | Lifecycle |
 |-------|-----------------|-----------|
 | The plan — what slices and phase groups exist | `SPEC.md` | durable |
+| The route decision — verdict, constraints, allowlist, validation baseline, input basis | `ROUTE.md` | durable |
 | Implementation progress — which slices are done, with commits, decisions, learnings | `NAVIGATION.md` | durable |
 | What's active right now | `.vine/ACTIVE` | ephemeral |
 | Handoff notes across a session gap | `PAUSE.md` | ephemeral |
@@ -450,7 +519,7 @@ Project *state* follows the same single-home discipline the Knowledge Boundary r
 
 ## Committing Artifacts
 
-Whether VINE artifacts (`CONTEXT.md`, `SPEC.md`, `NAVIGATION.md`, `EVOLUTION.md`, `PROJECT-MAP.md`) are committed is the repo's choice, drawn by `.gitignore`:
+Whether VINE artifacts (`CONTEXT.md`, `SPEC.md`, `ROUTE.md`, `NAVIGATION.md`, `EVOLUTION.md`, `PROJECT-MAP.md`) are committed is the repo's choice, drawn by `.gitignore`:
 
 - **Tracked** (`.vine/projects/` not gitignored) = the team-shared choice (see the Knowledge Boundary rule). The artifacts travel with the code through history and PRs.
 - **Untracked / personal scope** (gitignored, or a future `.vine.local/` root) = artifacts stay local to the engineer. Fully supported.
@@ -463,6 +532,7 @@ The journal-before-commit guarantee holds either way: `journal-check.sh` compare
 |--------------|----------------|------------------------------|
 | **Verify completion** (`vine:verify` wrap-up, after the engineer approves) | — | CONTEXT.md + PROJECT-MAP.md — their first entry into history |
 | **Inquire completion** (`vine:inquire` sign-off) | — | SPEC.md + the PROJECT-MAP.md inquire row |
+| **Navigate head** (`vine:navigate`, gate run before the first slice) | — | ROUTE.md — the gate record's entry into history (bundled with the first slice commit of the group) |
 | **Slice commit** (`vine:navigate` step 4c) | the slice's code | that slice's NAVIGATION.md journal entry + any SPEC.md deviation annotations made during the slice (step 6) |
 | **Phase-group boundary** (`vine:navigate` step 8) | — | PROJECT-MAP.md (navigate row, Milestones row → status / PR#) + the SPEC.md phase-group ✅ marker |
 | **Evolve commit** (`vine:evolve`) | — | EVOLUTION.md and the `.resolved` marker |


### PR DESCRIPTION
## What

VINE now decides and records how a scope of work is delivered — interactively
(the default, where a human reviews each change) or eligible to run headless (an
unattended agent runs, a reviewer checks after). This adds a new ROUTE.md gate
record (verdict + constraints + file allowlist + validation baseline + the state
it was computed against), a gate at the start of implementation that produces it,
a non-binding route preview during spec design, and a pointer to it in the
progress tracker.

## Why

This is the "route" stage of VINE's delegation loop — until now nothing decided
or recorded whether a scope could run unattended. The interactive path is
unchanged: the gate is a no-op for ordinary sessions and only ever *adds* the
headless option; a missing prerequisite withholds headless without touching the
interactive flow. Part of #54 (validation contract + routing-layer eligibility
gate); the headless contract that consumes the route lands in a later phase (#53).

## How to test

1. Run `/vine:navigate` on a feature interactively — confirm the new gate is a
   no-op (no ROUTE.md written) and the per-slice flow is unchanged.
2. Skim `references/STATE.md` for the ROUTE.md format and the PROJECT-MAP Route table.
3. Run `/trellis` — 11/11 commands + cross-reference anchors pass.

## Checklist

- [x] I've tested this in an actual VINE cycle (built via `/vine:navigate`; the gate no-op'd on this interactive run)
- [x] Changes are focused on a single concern (the route decision + its record)
- [x] Any new behavior is documented in the command files and STATE.md

---
Note: this touches core phase flow and the state model — part of the maintainer's
v0.4.0 routing-foundation cycle (ROADMAP), tracked in #54. Second of four phase-group
PRs for this cycle (Phase 1 was #94).