### PR TITLE
Routing foundation Phase 4: docs, reviewer orientation & trellis checks

### DIFF
--- a/.claude/commands/trellis.md
+++ b/.claude/commands/trellis.md
@@ -228,8 +228,8 @@ always runs regardless.
 ### 5a: Parse Artifact Templates from STATE.md
 
 Read `references/STATE.md`. Locate each artifact template by finding the `### <Name>.md`
-headings under `## State Files` (CONTEXT.md, SPEC.md, NAVIGATION.md, EVOLUTION.md) and
-under `## Per-Repo Artifacts` (PROFILE.md).
+headings under `## State Files` (CONTEXT.md, SPEC.md, ROUTE.md, NAVIGATION.md, EVOLUTION.md)
+and under `## Per-Repo Artifacts` (PROFILE.md).
 
 Each template is enclosed in a markdown code fence (` ```markdown ... ``` `). For each template:
 
@@ -238,7 +238,7 @@ Each template is enclosed in a markdown code fence (` ```markdown ... ``` `). Fo
    `<!-- optional -->` marker on the same line
 3. Record each heading's text (without the marker), heading level, and whether it's required
    or optional
-4. Map these to the artifact type (CONTEXT, SPEC, NAVIGATION, EVOLUTION, PROFILE)
+4. Map these to the artifact type (CONTEXT, SPEC, ROUTE, NAVIGATION, EVOLUTION, PROFILE)
 
 **Handling dynamic headings**: Some template headings contain placeholders like `[Name]` or
 `[Feature Name]`. For validation purposes, treat these as pattern prefixes. For example,
@@ -257,7 +257,7 @@ markers found at all), print a warning and skip Steps 6–7.
 
 Use Glob to find all artifacts in `.vine/projects/`:
 
-- Look for `CONTEXT.md`, `SPEC.md`, `NAVIGATION.md`, `EVOLUTION.md` under
+- Look for `CONTEXT.md`, `SPEC.md`, `ROUTE.md`, `NAVIGATION.md`, `EVOLUTION.md` under
   `.vine/projects/*/*/` (domain/feature-slug directories)
 - Look for `PROFILE.md` at `.vine/PROFILE.md`
 - **Filter out**: any path containing `.archive/` and any directory containing a `.resolved` file
@@ -277,7 +277,7 @@ results per check per artifact.
 
 ### Check A: Required Sections Present
 
-**Applies to**: all artifact types (CONTEXT, SPEC, NAVIGATION, EVOLUTION, PROFILE)
+**Applies to**: all artifact types (CONTEXT, SPEC, ROUTE, NAVIGATION, EVOLUTION, PROFILE)
 
 For each section marked `<!-- required -->` in the artifact's STATE.md template, verify that
 a matching heading exists in the actual artifact file.
@@ -354,6 +354,57 @@ For completed slices only, verify these fields are present as bold-prefixed list
 Pending or in-progress slices are not checked — NAVIGATION.md is built incrementally and
 partial files are expected.
 
+**Optional route fields — shape when present (#90 journal schema).** A completed slice may
+also carry the optional `**Route**`, `**Actor**`, `**Gear**` fields and a token-led
+`**Validation**`. These are `<!-- optional -->`: their **absence is never a failure** (a missing
+`Route` reads as `interactive`, a missing `Actor` as `human`). Validate only the shape of fields
+that *are* present:
+
+- `**Route**`, if present, uses exactly one of the closed vocabulary `interactive | headless |
+  headless-reentry`, followed by a `` `mechanism: ...` `` token (value may be `n/a`). This is the
+  same closed set as Check E (ROUTE.md) and the PROJECT-MAP Route table — the three surfaces must
+  stay comparable.
+- `**Gear**`, if present, is one of `free-climb` or `walk-me-through`.
+- `**Validation**` leads with a bare `pass` or `fail` token before any details.
+
+Like Check 11's naked-pointer floor, this shape check **does not run retroactively against
+immutable historical journals** — apply it to entries written under the current schema; a
+pre-#90 entry that records validation as free prose is not a failure.
+
+### Check E: ROUTE Verdict & Eligibility Legs Shape
+
+**Applies to**: ROUTE.md only
+
+Check A already confirms ROUTE.md's required sections are present (Verdict, Eligibility Legs,
+Constraints, Allowlist, Validation Baseline, Input Basis). This check validates the two fields
+whose shape is contractual:
+
+1. **Route verdict vocabulary**: The `**Route**` field under `### Verdict` must use exactly one
+   of `interactive`, `headless`, `headless-reentry`, followed by a `` `mechanism: ...` `` token
+   (value may be `n/a`). A route word outside the closed set, or a missing `mechanism:` token,
+   fails. Same closed vocabulary as the NAVIGATION `**Route**` field and the PROJECT-MAP Route
+   table.
+2. **Eligibility legs present**: The `### Eligibility Legs` section lists all four predicate legs
+   (Validation contract, Slice ACs, Independence, Bounded blast radius) as checklist items.
+   Whether each box is ticked is the gate's call, not trellis's — this is a structural check.
+
+ROUTE.md is optional with graceful absence: a feature with no ROUTE.md ran interactively and
+ungated, so Checks A and E simply don't run for it — **absence is not a failure**.
+
+### Check F: Validation Block Shape (repo-level, when present)
+
+**Applies to**: `.vine/context/shared.md` — repo-level, not a per-artifact check (so it has no
+column in the Step 7 table; report it as its own line like Check 10).
+
+When a `## Validation` block is present, verify it is a fenced YAML block whose keys are drawn
+only from the documented set — `lint`, `typecheck`, `test`, `test-all`, `build`, `extra` — and
+that `extra` (if present) is a list. An unknown key or a malformed block fails. **Absence is not
+a failure**: a repo with no `## Validation` block falls back to prose inference (the contract is
+optional, per `references/STATE.md`), so the check simply doesn't run.
+
+Like all of Steps 5–7, Checks E and F and the optional-route-field shape check are
+**session-judged and do not gate the `.vine/.trellis-ok` stamp** (Step 8).
+
 ## Step 7: Format Artifact Results
 
 Present artifact validation results after the command checks from Step 4. This step produces
@@ -390,26 +441,35 @@ Print a results table with artifacts as rows and checks as columns:
 ```
 ## Artifact Validation
 
-| Artifact                              | Sections | Table | Slice Fields | Nav Fields |
-|---------------------------------------|----------|-------|--------------|------------|
-| .vine/PROFILE.md                      | ✅       | ✅    | —            | —          |
-| .vine/projects/auth/login/CONTEXT.md  | ✅       | —     | —            | —          |
-| .vine/projects/auth/login/SPEC.md     | ✅       | —     | ✅           | —          |
-| .vine/projects/auth/login/NAV...md    | ✅       | —     | —            | ✅         |
-| ...                                   |          |       |              |            |
+| Artifact                              | Sections | Table | Slice Fields | Nav Fields | Route |
+|---------------------------------------|----------|-------|--------------|------------|-------|
+| .vine/PROFILE.md                      | ✅       | ✅    | —            | —          | —     |
+| .vine/projects/auth/login/CONTEXT.md  | ✅       | —     | —            | —          | —     |
+| .vine/projects/auth/login/SPEC.md     | ✅       | —     | ✅           | —          | —     |
+| .vine/projects/auth/login/ROUTE.md    | ✅       | —     | —            | —          | ✅    |
+| .vine/projects/auth/login/NAV...md    | ✅       | —     | —            | ✅         | —     |
+| ...                                   |          |       |              |            |       |
 ```
 
 Column mapping:
 - **Sections** → Check A (applies to all)
 - **Table** → Check B (PROFILE only)
 - **Slice Fields** → Check C (SPEC only)
-- **Nav Fields** → Check D (NAVIGATION only)
+- **Nav Fields** → Check D (NAVIGATION only — includes the optional route-field shape check)
+- **Route** → Check E (ROUTE.md only)
 
 Use `✅` for pass, `❌` for fail, `—` for not applicable (the check doesn't apply to this
 artifact type).
 
 After the table, print any unmarked heading warnings from Step 5a (headings in STATE.md
 templates that lack a `<!-- required -->` or `<!-- optional -->` marker).
+
+Then print the Check F result as its own repo-level line (like Check 10's anchor line):
+
+- `## Validation` block present and well-formed: **"✅ Validation block valid (N keys)"**
+- Present but malformed (unknown key, or `extra` not a list): **"❌ Validation block: <what was
+  wrong>"**
+- Absent: **"— Validation block: none (prose-inference fallback)"** — not a failure.
 
 ### Combined Summary
 
@@ -452,5 +512,8 @@ drifted between this skill and `trellis-check.sh` and the drift itself needs fix
 Scope notes: warnings (legacy references, unmarked headings) do not block a pass stamp.
 Artifact validation failures don't either — artifacts are often work-in-progress journals,
 and gating command commits on artifact state would block unrelated work. The stamp certifies
-command structure and cross-reference anchors only; artifact validation (Steps 5–7) stays
-session-judged and is not stamped.
+command structure and cross-reference anchors only; **all of Steps 5–7 stays session-judged and
+is not stamped** — including the ROUTE.md checks (A, E), the optional route-field shape check
+(D), and the repo-level Validation-block check (F, which reads `.vine/context/shared.md`). The
+script never reads those surfaces, so adding or malforming a ROUTE.md, a route field, or the
+Validation block can never block a command commit.

--- a/.vine/context/review.md
+++ b/.vine/context/review.md
@@ -3,8 +3,8 @@
 <!-- Promoted from cycle-0 spike scaffold (2026-06-12, Q4 verdict: sufficient entry
      point first try — evidence in workflow/coordination-spike EVOLUTION.md).
      Deliberately minimal: it tells the reviewer HOW to orient and WHAT to produce,
-     not the artifact-format tribal knowledge. Cycle 1 adds "read the durable gate
-     record" to the orientation order once that artifact exists (#54/#53). -->
+     not the artifact-format tribal knowledge. Cycle 1 added the durable gate record
+     (ROUTE.md) to the orientation order — step 2 below (#54/#53). -->
 
 ## Role
 
@@ -22,15 +22,25 @@ Read in this order; later items will make sense because of earlier ones:
 
 1. **The originating scope** — the issue/ticket the work was delegated against, or the
    feature's SPEC.md if one exists. This tells you what was supposed to happen.
-2. **The feature's artifact directory** — `.vine/projects/<domain>/<feature-slug>/`.
-   Read every `.md` file present. NAVIGATION.md is the implementation journal: per-slice
-   entries record approach, validation, decisions, and acceptance criteria. Sections
-   after the slice entries (remaining work, decision logs, handoff notes) are the
-   outbound handoff — they are addressed to you.
-3. **The commits** — `git log` + `git show` for each commit the journal names. The diff
+2. **The gate record** — `ROUTE.md` in the feature directory, if present. This is the
+   routing decision the work was authorized under: the verdict (interactive vs headless),
+   the **allowlist** of files the work was permitted to touch, the **constraints** a
+   headless actor had to honor, the **validation baseline** that had to stay green, and
+   the **input basis** (HEAD SHA, in-flight set) with its computed-at stamp. Read it
+   before the journal and commits — it frames what you check the work *against*: did the
+   diff stay inside the allowlist, did the validation baseline run, and does the stamp's
+   input basis still match the state the work actually executed on (authorization-vs-
+   execution drift is a finding). Absent ROUTE.md, the run was interactive and ungated —
+   move to the next step.
+3. **The feature's artifact directory** — `.vine/projects/<domain>/<feature-slug>/`.
+   Read every `.md` file present (ROUTE.md you've already read above). NAVIGATION.md is
+   the implementation journal: per-slice entries record approach, validation, decisions,
+   and acceptance criteria. Sections after the slice entries (remaining work, decision
+   logs, handoff notes) are the outbound handoff — they are addressed to you.
+4. **The commits** — `git log` + `git show` for each commit the journal names. The diff
    is the ground truth; the journal is the actor's account of it. Discrepancies between
    the two are findings.
-4. **The touched files in their final state** — read enough of each changed file to
+5. **The touched files in their final state** — read enough of each changed file to
    judge the change in context, not just the diff hunks.
 
 ## What to Scrutinize

--- a/.vine/context/shared.md
+++ b/.vine/context/shared.md
@@ -47,6 +47,17 @@ When adding or removing a VINE command, update all of these:
 - `references/STATE.md` — if the command affects the artifact chain
 - `.vine/context/verify.md` — command count reference
 
+### State Artifact Addition Checklist
+When adding or removing a state artifact (the ROUTE.md addition in the routing-foundation cycle is
+the worked example), update all of these:
+- `references/STATE.md` — the artifact template (every heading marked `<!-- required -->` /
+  `<!-- optional -->`), its place in the artifact chain, and the Source-of-Truth and Committing
+  Artifacts tables
+- `CLAUDE.md` — the State Artifact Chain line
+- `README.md` — the State Artifacts table
+- `.claude/commands/trellis.md` — the Step 5a template-parse list, the Step 5b discovery glob, and
+  Check A's applies-to set (plus a shape check like Check E if the artifact has contractual fields)
+
 ### Availability-Gated Pointer
 When VINE knowledge must be referenced from a surface non-VINE teammates load (CLAUDE.md), use an availability-gated pointer: gate the suggestion on whether the vine commands are actually present in the session's skill list, and point at this file for routing. The gate is what Claude can see, not where files live — so mixed-adoption teams and global installs both resolve correctly. Future commands reuse this pattern instead of reinventing the mixed-adoption answer.
 

--- a/.vine/projects/workflow/routing-foundation/EVOLUTION.md
+++ b/.vine/projects/workflow/routing-foundation/EVOLUTION.md
@@ -1,0 +1,215 @@
+# Evolution Report: Routing Foundation (v0.4.0 Cycle 1)
+## Date: 2026-06-16
+
+### Product Evolution
+
+#### Acceptance Criteria Results
+
+Full-feature verification (evolve tier) delegated to `vine-verification` at full-feature
+scope. **All 10 cycle-level acceptance criteria MET.** `sh .vine/scripts/trellis-check.sh`
+passes clean (11/11 commands + 8/8 cross-reference anchors). Per-slice and phase-group tiers
+all passed during navigate (17 slices + 2 in-phase boundary fixes + 2 phase-group runs, every
+one `pass`).
+
+| Cycle AC (SPEC) | Evidence (slice / commit) |
+|---|---|
+| 1. Precedence resolves at load time | Slice 1 `0c81247` + Slice 2 `bc5d5ca` + Phase-1 boundary `53b0200` (init template) |
+| 2. Validation contract exists + consumed | Slice 3 `ea8e30b` + Slice 4 `b47e71c` + Slice 5 `3a26f48` |
+| 3. Eligibility gate at navigate-head | Slice 7 `92c13ad` |
+| 4. ROUTE.md complete record | Slice 6 `172867b` + Slice 9 `42b576a` (PROJECT-MAP link) |
+| 5. Headless contract holds | Slice 11 `99e19fb` + Slice 12 `faa4b4e` |
+| 6. Decision Delegation policy | Slice 10 `bc79152` |
+| 7. Journal schema carries route data | Slice 13 `a7f8cf3` + Phase-3 boundary `7ad1521` (lockstep) |
+| 8. Reviewer reads gate record | Slice 14 `9baacaf` |
+| 9. Distribution surfaces updated | Slice 15 `f6df658` + Slice 16 `6983c3f` + Slice 17 `6dd5456` |
+| 10. Backward compatibility | Cross-cutting — verified at Phase-1, Phase-3, Phase-4 boundaries |
+
+No unaccounted criteria — every cycle-level AC maps to a slice with a recorded commit.
+
+**Cross-cutting integration (full-feature tier only):** lockstep between `references/STATE.md`
+templates and the `navigate.md` writer confirmed (the Phase-3 `Decisions made during
+implementation` label mismatch stayed fixed); controlled Route vocabulary
+(`interactive | headless | headless-reentry`) consistent across all three authoritative
+surfaces; all new internal anchors (`#reference-legibility`, `#source-of-truth-vs-derived-views`,
+`#committing-artifacts`) resolve; `.gitignore` `.vine/context/*.local.md` pattern correct; no
+dangling ROUTE.md references on swept surfaces (CLAUDE.md chain, README table, shared.md
+checklist).
+
+**One benign warning (verified directly, no defect):** `navigate.md:233` uses
+`<!-- decision-class: ... -->` as *explanatory prose* (instructing the actor to read each
+site's tag), not a real site tag. 31 real site tags confirmed across 7 commands. Recorded as a
+forward-note for an eventual mechanical tag-parser (Follow-Up).
+
+#### Spec Deviations
+
+No behavioral deviations. Three descriptive **file-hint** corrections, each reasoned to the
+right target and explicitly flagged in NAVIGATION.md as descriptive-only (no SPEC annotation
+needed):
+
+| Slice | SPEC hint | Reality / action |
+|---|---|---|
+| 8 | "alongside the existing gearing preview in inquire" | The gearing preview lives in `verify.md`, not inquire. Modeled the route preview on verify's pattern, placed in inquire's completion block per the AC. |
+| 15 | seam "after `## Context Overlays`" or "under `## How VINE compares`" | Placed after `## State Artifacts` instead — strictly better legibility (no forward references; the section leans on ROUTE.md / journal / reviewer role introduced by that point). |
+| 17 | `commands/vine/verify.md (count reference)` | The count reference lives in `.vine/context/verify.md`; `commands/vine/verify.md` carries none. Command count is 11, unchanged this cycle, so no count edit was needed anywhere. |
+
+Root cause is benign: the verify map predated main's #92 (line shifts), so a long multi-PR
+cycle accumulates minor hint drift. Navigate correctly treats file-hints as descriptive
+candidates, not mandates.
+
+#### Follow-Up Items
+
+- **Close implemented issues (actioned):** `#54` (validation + eligibility gate), `#53`
+  (headless autonomy), `#90` (journal schema) are fully delivered — set to close via the Phase 4
+  PR (`Closes #53, #54, #90`).
+- **#55 commented (actioned):** the routing-policy half (Decision Delegation) landed this cycle;
+  the profile-rework half (strip delegation/risk from PROFILE.md, keep depth + growth) remains
+  open — this cycle delivered the precondition, not the rework.
+- **New issue filed (actioned): [#99](https://github.com/moduloMoments/VINE/issues/99)** —
+  `journal-check.sh` observability: emit a visible signal on fire-and-pass so it is
+  distinguishable from didn't-fire. Hook-scoping debt from the cycle-0 spike, orthogonal to
+  routing. Distinct from #90 (schema, implemented).
+- **Deferred / already tracked:** `#51` (`.vine/knowledge/<domain>.md`, cycle 3); federated
+  knowledge sync (2027-shaped); the decision-class prose-occurrence note (very low priority —
+  only matters if a mechanical tag-parser is ever built).
+
+#### Multi-PR Status
+
+| Phase | Slices | PR | Status |
+|-------|--------|----|--------|
+| Phase 1: Precedence & Validation Foundation | 1-5 | [#94](https://github.com/moduloMoments/VINE/pull/94) | Merged (clean, no review comments, no CI) |
+| Phase 2: Eligibility Gate & Route Record | 6-9 | [#97](https://github.com/moduloMoments/VINE/pull/97) | Merged (clean) |
+| Phase 3: Headless Contract & Journaling | 10-13 | [#98](https://github.com/moduloMoments/VINE/pull/98) | Merged (clean) |
+| Phase 4: Docs, Reviewer & Trellis | 14-17 | — | Ready to open (6 commits ahead of origin/main) |
+
+This repo has no CI (pure markdown); the validation contract is `trellis-check.sh`, which
+passed green at every slice and at the full-feature tier.
+
+### Agent Evolution
+
+#### CLAUDE.md Suggestions
+
+- **Unnumbered-section command-authoring convention** — **accepted**. Added under Command
+  Authoring Conventions: prefer an unnumbered `###` section over renumbering existing steps,
+  because renumbering ripples through every `step N` cross-reference (the drift `/trellis`
+  Check 10 catches), and an unnumbered section signals "runs once / out of the numbered flow."
+  Reinforced twice this cycle (Slices 7 and 12, both navigate-head additions).
+
+#### Skill Suggestions
+
+None. The one repeatable workflow this cycle produced — the multi-surface sweep when adding a
+state artifact — was already codified as the **State Artifact Addition Checklist** in
+`.vine/context/shared.md` (Slice 17). For a pure-markdown framework, in-repo checklists are the
+right unit, not skills.
+
+#### VINE Process Observations
+
+- **Phase-group boundary verification earned its keep twice.** It caught the init-template
+  precedence gap (Phase 1) and a years-old `Decisions made` field-label drift (Phase 3) that
+  was invisible until the #90 schema contract referenced the field by name. Strong validation
+  of the verification-tier design (per-slice → phase-group → full-feature).
+- **Multi-PR tracking held the thread cleanly.** 4 phases → 4 PRs, clean rebases (`--onto
+  origin/main` to drop merged-phase noise), PROJECT-MAP Milestones table tracked across
+  sessions.
+- **SPEC file-hints drift over a long cycle.** Three descriptive-hint imprecisions (Slices 8,
+  15, 17) because main moved under the cycle. No fix — navigate correctly treats hints as
+  candidates — but a signal that file-hints in a multi-PR SPEC age faster than the ACs do.
+- **Meta-friction (dogfooding):** editing `navigate.md` while `navigate.md` guided the work was
+  handled by the unnumbered-section choice (keeps navigate's own trellis green while extending
+  it). Worked cleanly; no confusion.
+
+#### Context Overlay Updates
+
+None proposed. Slice 17 already swept the overlay surfaces it touched (State Artifact Addition
+Checklist in shared.md); no genuine new overlay content surfaced this cycle.
+
+### User Evolution
+
+#### Engineer Contributions
+
+- **Ran the full 17-slice / 4-PR cycle in free-climb gearing**, set up front each phase — heavy,
+  sustained delegation that is itself a confident-domain signal.
+- **The load-bearing steering call was the Phase-1 boundary "fix in-phase" decision:** rather
+  than carry a known-graceful-but-incoherent init-template precedence gap across the cycle's
+  other PRs, close the coherence gap the phase group itself created. That set the precedent the
+  Phase-3 boundary lockstep fix then followed — a reusable judgment about *when* a discovered
+  gap is in-scope (the phase created it) versus spin-out work.
+
+This was routine work in Rob's comfort zone; no manufactured growth narrative.
+
+#### Profile Updates
+
+- **`workflow` domain — kept `confident` (the ceiling), Notes + Last Updated refreshed** to
+  2026-06-16, recording the routing-foundation cycle and the in-phase-fix precedent. No level
+  change warranted.
+- **Growth log — skipped** (engineer's call; routine confident-domain work).
+
+#### Claude Memory Suggestions
+
+None persisted. The in-phase-fix pattern was offered and declined for memory — it's
+situational and complements the existing spawn-scoped-tasks preference (out-of-scope → spawn;
+in-scope-but-discovered → fix now) without needing its own durable entry.
+
+### Handoff Package
+
+#### PR Description
+
+```markdown
+## Summary
+Final phase of the routing-foundation cycle (v0.4.0 Cycle 1): make the new routing surfaces
+discoverable, reviewable, and validated. Phases 1–3 built the precedence model, the validation
+contract, the navigate-head eligibility gate + ROUTE.md record, the headless autonomy contract,
+and the journal schema. This phase wires those into the docs, the reviewer's orientation, and
+trellis.
+
+## Changes
+- review.md: a "gate record" step in the reviewer's orientation order — read ROUTE.md (verdict,
+  allowlist, constraints, validation baseline, stamp) before the journal/commits, so execution
+  is checked against its authorization basis. Graceful when ROUTE.md is absent.
+- README: an "Agents running VINE" section — the routing gate, the gate record, the reviewer
+  role, and the agents/ directory, one screen, links for depth.
+- trellis: artifact-tier checks (session-judged, never gate the command-commit stamp) for
+  ROUTE.md format (Checks A + E), optional journal route fields (Check D), and the Validation
+  block shape (Check F). All skip gracefully when their surface is absent.
+- Cross-reference sweep: ROUTE.md added to CLAUDE.md's artifact chain and README's State
+  Artifacts table; a new State Artifact Addition Checklist in shared.md.
+
+## Decisions Made
+- New checks land in trellis's already-unstamped artifact tier, so "don't gate the stamp" needs
+  no new mechanism — it falls out of placement.
+- ROUTE.md goes in *enumerating* surfaces (artifact chain, tables) but not *narrative*
+  "four phases" prose — it's navigate-internal, not a fifth phase.
+
+## Testing
+- sh .vine/scripts/trellis-check.sh → 11/11 commands + 8/8 anchors, clean.
+- Full-feature verification (evolve tier): all 10 cycle-level ACs MET; backward compatibility
+  holds (ROUTE.md / journal route fields / Validation block all degrade to interactive defaults
+  when absent).
+
+## Follow-up
+Closes #53, #54, #90. The routing-policy half of #55 landed (profile-rework half remains).
+New: #99 (journal-check observability).
+```
+
+#### Reviewer Notes
+
+- **This is the cycle's documentation/validation tail, not new mechanism** — Phases 1–3 (already
+  merged as #94/#97/#98) built the routing machinery; Phase 4 only surfaces it. The diff is docs,
+  reviewer orientation, and trellis checks.
+- **Backward compatibility is the load-bearing invariant** (AC 10). Every new surface is optional
+  with graceful absence — confirm a `.vine/` setup with no ROUTE.md, no journal route fields, and
+  no `## Validation` block still works unchanged. The interactive path is never gated; the gate
+  only ever *adds* the headless option.
+- **The new trellis checks are session-judged and must not gate `.vine/.trellis-ok`** — they live
+  in Steps 5–7 (the artifact tier), which `trellis-check.sh` never runs. The script is unchanged,
+  by design.
+- **Tribal-knowledge context** (from CONTEXT.md): the spike's "map, not mechanism" finding means
+  the headless contract is a decision protocol + handoff format, both mechanism-agnostic — it
+  survives whatever launches the actor. Don't expect VINE to store actor permissions; those are
+  provisioning-time human authority, outside the artifact chain.
+
+#### Commit Suggestions
+
+Phase 4 is 6 commits on `feature/routing-foundation` ahead of `origin/main` (919aa56 Phase-3
+tracker + 9baacaf, f6df658, 6983c3f, 6dd5456 slice commits + ac472aa tracker/boundary). They tell
+the slice story cleanly; open the PR against `origin/main` as-is (no squash needed pre-PR — GitHub
+squash-merge on merge, matching the prior three phases).

--- a/.vine/projects/workflow/routing-foundation/NAVIGATION.md
+++ b/.vine/projects/workflow/routing-foundation/NAVIGATION.md
@@ -725,7 +725,7 @@ cross-references and counts.
 
 ### Slice 15: README "Agents running VINE" section — Complete
 - **Started**: 2026-06-16 10:08
-- **Commit**: pending
+- **Commit**: f6df658
 - **Route**: interactive — `mechanism: n/a`
 - **Actor**: human (Rob + Claude)
 - **Gear**: free-climb
@@ -768,3 +768,62 @@ cross-references and counts.
     constraint is "no forward references," and the seam that satisfies it (after the artifacts the
     section depends on) won out over the literally-suggested ones. Same instinct as Slice 8's
     "the gearing preview is in verify, not inquire": treat file hints as descriptive.
+
+### Slice 16: Trellis artifact-tier checks — Complete
+- **Started**: 2026-06-16 10:18
+- **Commit**: pending
+- **Route**: interactive — `mechanism: n/a`
+- **Actor**: human (Rob + Claude)
+- **Gear**: free-climb
+- **Approach taken**: Added the new surfaces to `.claude/commands/trellis.md`'s artifact tier
+  (Steps 5–7), which is session-judged and explicitly never stamped — the design hook that
+  satisfies "do not gate `.vine/.trellis-ok`" for free (the mechanical `trellis-check.sh` runs only
+  Steps 1–4 + Check 10, never the artifact tier). Wired ROUTE.md into the Step 5a template parse
+  list and the Step 5b discovery glob and the Check A applies-to set (so ROUTE.md's six required
+  sections are validated by the existing generic required-sections check). Added **Check E** (ROUTE
+  Verdict & Eligibility Legs Shape — closed route vocabulary + `mechanism:` token, four legs
+  present as a structural check). Extended **Check D** with an optional-route-field shape check
+  (`Route`/`Gear`/token-led `Validation` validated only when present; absence never a failure; and
+  — mirroring Check 11 — not run retroactively against pre-#90 historical journals). Added
+  **Check F** (repo-level Validation-block shape in shared.md: keys ⊆ the documented six, `extra`
+  is a list, absent ⇒ skip not fail). Updated Step 7 (Route column + column mapping + Check F
+  repo-level line) and Step 8's scope note to enumerate A/E/D/F as session-judged and unstamped.
+- **Deviations from spec**: None.
+- **Validation**: pass — `sh .vine/scripts/trellis-check.sh` 11/11 commands + 8/8 anchors (the
+  script is unchanged, so the stamp logic is untouched — exactly the point). Graceful-absence paths
+  exercised on this repo: no ROUTE.md exists (Checks A/E don't run — this feature ran interactive),
+  and the `## Validation` block at shared.md:188 is well-formed `extra`-only (Check F → valid).
+  trellis.md lives in `.claude/commands/` (contributor tool), not `commands/vine/`, so editing it
+  doesn't trip the command-commit gate.
+- **Decisions made during implementation**:
+  - Put all three checks in the artifact tier (Steps 5–7) rather than the command tier (Steps
+    1–4) — the artifact tier is already session-judged and unstamped, so "don't gate the stamp"
+    needs no new mechanism; it's structural. Left `trellis-check.sh` untouched. (decided by:
+    claude) [confidence: high]
+  - Reused the generic Check A for ROUTE.md's required sections (just added ROUTE.md to the parse
+    + discovery + applies-to lists) and scoped Check E to only the two *shape*-contractual fields
+    (verdict vocab, legs present) — avoids duplicating required-section logic per type. (decided
+    by: claude) [confidence: high]
+  - Made the optional-route-field shape check (Check D extension) non-retroactive for historical
+    journals, mirroring Check 11's "never runs retroactively against immutable historical
+    artifacts" — a pre-#90 entry with free-prose validation must not start failing. (decided by:
+    claude) [confidence: high]
+  - Verified ROUTE.md's metadata lines (`## Feature:`, `## Computed at:`) are exactly analogous to
+    CONTEXT.md's `## Date:` / `## Author:` before adding it — ROUTE.md is just another State File,
+    so it introduces no new unmarked-heading-warning class (direct check, not assumption).
+    (decided by: claude) [confidence: high]
+- **Acceptance criteria**:
+  - [x] Checks cover ROUTE.md format (Check A required sections + Check E shape), journal route
+        fields (Check D extension), and the Validation block presence/shape when present (Check F)
+  - [x] They are session-judged and do not gate the `.vine/.trellis-ok` command-commit stamp
+        (all in Steps 5–7; script unchanged; Step 8 scope note enumerates them)
+  - [x] Absence of the surfaces is not a failure (ROUTE.md absent ⇒ A/E skip; route fields absent
+        ⇒ D passes; Validation block absent ⇒ F skips to prose fallback)
+- **Engineer feedback incorporated**: None this slice (free climb).
+- **Learnings**:
+  - Engineer → Claude: None specific to this slice.
+  - Claude → Engineer: The "don't gate the stamp" requirement wasn't a new flag to add — it was a
+    placement decision. trellis already splits a stamped mechanical command tier from a
+    session-judged artifact tier; putting the new checks in the tier that's *already* unstamped
+    made the constraint fall out of the structure instead of needing enforcement. The cleanest way
+    to honor a constraint is often to land the work where the constraint already holds.

--- a/.vine/projects/workflow/routing-foundation/NAVIGATION.md
+++ b/.vine/projects/workflow/routing-foundation/NAVIGATION.md
@@ -771,7 +771,7 @@ cross-references and counts.
 
 ### Slice 16: Trellis artifact-tier checks — Complete
 - **Started**: 2026-06-16 10:18
-- **Commit**: pending
+- **Commit**: 6983c3f
 - **Route**: interactive — `mechanism: n/a`
 - **Actor**: human (Rob + Claude)
 - **Gear**: free-climb
@@ -827,3 +827,58 @@ cross-references and counts.
     session-judged artifact tier; putting the new checks in the tier that's *already* unstamped
     made the constraint fall out of the structure instead of needing enforcement. The cleanest way
     to honor a constraint is often to land the work where the constraint already holds.
+
+### Slice 17: Command Addition Checklist + count sweeps — Complete
+- **Started**: 2026-06-16 10:34
+- **Commit**: pending
+- **Route**: interactive — `mechanism: n/a`
+- **Actor**: human (Rob + Claude)
+- **Gear**: free-climb
+- **Approach taken**: Swept the cross-reference surfaces for the cycle's new artifact (ROUTE.md)
+  and reconciled the carried discovered item. Three real gaps fixed: (1) **CLAUDE.md** State
+  Artifact Chain (line 36) — the carried Slice-6 discovered item — now names ROUTE.md's optional
+  position between SPEC.md and NAVIGATION.md with its graceful-absence note (keeps the canonical
+  four-phase chain visible while placing ROUTE.md); (2) **README.md** State Artifacts table — added
+  a ROUTE.md row in chain order (after SPEC, before NAVIGATION), marked optional/headless-eligible;
+  (3) **`.vine/context/shared.md`** — added a sibling **State Artifact Addition Checklist** next to
+  the Command Addition Checklist, codifying the multi-surface sync this cycle exercised (STATE.md
+  template + chain + tables, CLAUDE.md chain, README table, trellis Step 5a/5b/Check-A + shape
+  check). STATE.md needed no edit — Slices 6/13 already wired ROUTE.md into its chain,
+  Source-of-Truth and Committing-Artifacts tables (verified: 15 ROUTE.md references).
+- **Deviations from spec**: The spec's Slice 17 file hint named `commands/vine/verify.md (count
+  reference)`, but the "all 11 command files" count reference actually lives in
+  `.vine/context/verify.md:8` (where the Command Addition Checklist correctly points) —
+  `commands/vine/verify.md` carries no count. And the command count is **11, unchanged** this cycle
+  (Phase 4 added docs/checks, no commands), so no count edit was needed anywhere. Same descriptive-
+  hint imprecision noted in Slices 8 and 15; not an AC, no SPEC annotation needed.
+- **Validation**: pass — `sh .vine/scripts/trellis-check.sh` 11/11 commands + 8/8 anchors.
+  Consistency grep confirms ROUTE.md now appears in CLAUDE.md chain (1), README State Artifacts
+  table (1), STATE.md source (15), and the new shared.md checklist (1). No `commands/vine/` files
+  touched, so the command-commit gate is not involved.
+- **Decisions made during implementation**:
+  - Inserted ROUTE.md into the *enumerating* surfaces (CLAUDE.md chain, README artifacts table)
+    but left the *narrative* "four phases" lines (README:326/:385, init.md:236) unchanged — those
+    describe the four-phase flow, and ROUTE.md is navigate-internal (not a fifth phase), so adding
+    it there would contradict "four phases." Enumerations include it; phase-flow prose doesn't.
+    (decided by: claude) [confidence: high]
+  - Added a separate State Artifact Addition Checklist rather than overloading the Command
+    Addition Checklist — adding an artifact and adding a command touch different surface sets, and
+    this cycle's ROUTE.md work is the concrete worked example to anchor it. (decided by: claude)
+    [confidence: high]
+  - Left `commands/vine/verify.md` untouched — no count reference there, and 11 is unchanged.
+    Verified by grep rather than editing on the spec hint's say-so. (decided by: claude)
+    [confidence: high]
+- **Acceptance criteria**:
+  - [x] Counts and cross-references consistent across CLAUDE.md, README, STATE.md, and verify.md
+        (ROUTE.md in all enumerating surfaces; command count 11 consistent and unchanged)
+  - [x] The checklist reflects the new surfaces (new State Artifact Addition Checklist covering
+        STATE.md, CLAUDE.md, README, and trellis)
+  - [x] `/trellis` passes (11/11 + 8 anchors)
+- **Engineer feedback incorporated**: None this slice (free climb).
+- **Learnings**:
+  - Engineer → Claude: None specific to this slice.
+  - Claude → Engineer: A "consistency sweep" is really two distinct surface classes — enumerations
+    (which must list every artifact) and narratives (which describe a flow and shouldn't be forced
+    to enumerate). ROUTE.md belongs in the first, not the second; conflating them would have
+    "fixed" the four-phase story into a wrong five-phase one. The sweep's judgment was *which*
+    references are enumerations, not mechanically find-replacing the chain string everywhere.

--- a/.vine/projects/workflow/routing-foundation/NAVIGATION.md
+++ b/.vine/projects/workflow/routing-foundation/NAVIGATION.md
@@ -680,7 +680,7 @@ cross-references and counts.
 
 ### Slice 14: review.md gate-record orientation step — Complete
 - **Started**: 2026-06-16 10:01
-- **Commit**: pending
+- **Commit**: 9baacaf
 - **Route**: interactive — `mechanism: n/a`
 - **Actor**: human (Rob + Claude)
 - **Gear**: free-climb
@@ -722,3 +722,49 @@ cross-references and counts.
     because of earlier ones") — the gate record's *value* is positional: it only frames the
     journal/commit reads if it's read before them, so where it lands in the list is the design
     decision, not just that it's present.
+
+### Slice 15: README "Agents running VINE" section — Complete
+- **Started**: 2026-06-16 10:08
+- **Commit**: pending
+- **Route**: interactive — `mechanism: n/a`
+- **Actor**: human (Rob + Claude)
+- **Gear**: free-climb
+- **Approach taken**: Added a `## Agents running VINE` section to `README.md`, placed after
+  `## State Artifacts` and before `## Engineer Profile` — the seam where the artifacts (ROUTE.md,
+  the journal handoff) and the reviewer role it references have just been introduced, so the
+  section reads without forward-pointing. Four plain-language subsections, one screen: **the
+  routing gate** (four-leg eligibility, frames headless as opt-in and the gate as withholding-only
+  so the interactive path is untouched); **the gate record** (ROUTE.md's allowlist / constraints /
+  validation baseline / stamp, and the bound headless run + escalate-don't-guess behavior with the
+  human-required/default-able tagging); **the reviewer** (links `.vine/context/review.md`, orient
+  + produce); **the agents** (`agents/` dir, names both shipped agents and their roles). Closes
+  with a single STATE.md link for ROUTE.md format + delegation/handoff contracts (link-don't-inline
+  per the PR-description discipline).
+- **Deviations from spec**: None. The spec's file hint named two candidate seams ("after
+  `## Context Overlays`" or "under `## How VINE compares`"); chose after `## State Artifacts`
+  instead — strictly better for legibility because the section leans on ROUTE.md / journal / the
+  review role, all introduced by that point, so nothing reads forward. Descriptive hint, not an
+  AC; no SPEC annotation needed.
+- **Validation**: pass — `sh .vine/scripts/trellis-check.sh` 11/11 commands + 8/8 anchors; all
+  three new relative links resolve (`.vine/context/review.md`, `agents/`, `references/STATE.md`
+  all exist). README is not a command file, so the command-commit gate is not involved.
+- **Decisions made during implementation**:
+  - Placed the section after State Artifacts rather than either spec-suggested seam — legibility
+    (no forward references) over the literal hint. (decided by: claude) [confidence: high]
+  - Named both shipped agents (`vine-verification`, `vine-codebase-explorer`) and noted they're
+    identical interactive-or-headless — the AC says "`agents/` is treated"; naming the concrete
+    contents beats a vague pointer. (decided by: claude) [confidence: high]
+  - Kept it to one screen with a single STATE.md link for depth rather than inlining the ROUTE.md
+    format / delegation policy — the PR-description / Reference Legibility discipline applied to a
+    README section. (decided by: claude) [confidence: high]
+- **Acceptance criteria**:
+  - [x] A named section covers running VINE headless and the reviewer role
+  - [x] `agents/` is treated (both shipped agents named with their roles)
+  - [x] One screen, plain language, links for depth (PR-description discipline)
+- **Engineer feedback incorporated**: None this slice (free climb).
+- **Learnings**:
+  - Engineer → Claude: None specific to this slice.
+  - Claude → Engineer: A spec file-hint names *candidate* locations, not a mandate — the real
+    constraint is "no forward references," and the seam that satisfies it (after the artifacts the
+    section depends on) won out over the literally-suggested ones. Same instinct as Slice 8's
+    "the gearing preview is in verify, not inquire": treat file hints as descriptive.

--- a/.vine/projects/workflow/routing-foundation/NAVIGATION.md
+++ b/.vine/projects/workflow/routing-foundation/NAVIGATION.md
@@ -668,3 +668,57 @@ handoff (Slice 12), and the #90 journal schema (Slice 13).
     because a contract forces you to name the field precisely and then someone checks it against
     practice. The phase-group verification earned its keep here: the mismatch was invisible until
     a contract referenced the field by name.
+
+## Phase 4: Docs, Reviewer & Trellis (Slices 14-17)
+
+Resumed 2026-06-16 10:01 in free-climb gearing (engineer choice; profile confident/workflow).
+Branch even with `origin/main` + 1 local tracker commit (919aa56, Phase-3-shipped), clean tree,
+no open PRs in flight. Routing gate at navigate-head is a no-op this session — human-driven,
+route is `interactive`, no ROUTE.md written. Making the routing surfaces discoverable (README),
+reviewable (review.md orientation), and validated (trellis artifact checks), then sweeping
+cross-references and counts.
+
+### Slice 14: review.md gate-record orientation step — Complete
+- **Started**: 2026-06-16 10:01
+- **Commit**: pending
+- **Route**: interactive — `mechanism: n/a`
+- **Actor**: human (Rob + Claude)
+- **Gear**: free-climb
+- **Approach taken**: Added a new step 2, **The gate record**, to `.vine/context/review.md`'s
+  Orientation Order — placed after the originating scope (intent) and before the artifact
+  directory / journal / commits (execution), since ROUTE.md is the *authorization* basis the
+  reviewer checks execution against. The step names what to read it for (verdict, allowlist,
+  constraints, validation baseline, input basis + stamp) and the three checks it frames (diff
+  stayed inside the allowlist; validation baseline ran; stamp's input basis still matches
+  execution state — authorization-vs-execution drift is a finding), with explicit graceful
+  absence ("absent ROUTE.md, the run was interactive and ungated — move to the next step").
+  Renumbered the following steps (artifact directory → 3, commits → 4, touched files → 5) and
+  added a parenthetical to step 3 so ROUTE.md isn't re-read redundantly. Resolved the header
+  follow-up comment: rewrote its forward-looking "Cycle 1 adds … once that artifact exists"
+  sentence into a resolved note pointing at step 2 (kept the promotion provenance trail).
+- **Deviations from spec**: None.
+- **Validation**: pass — `sh .vine/scripts/trellis-check.sh` 11/11 commands + 8/8 cross-reference
+  anchors. review.md is an overlay file (not a command file), so the `.vine/.trellis-ok`
+  command-commit gate is not involved; no required/optional marker applies (not a STATE.md
+  template).
+- **Decisions made during implementation**:
+  - Placed the gate record as step 2 (between scope and the artifact directory) rather than
+    folding it into the existing "read every .md" step — the reviewer needs the authorization
+    boundaries *before* reading the journal/commits so they have something to check execution
+    against, and a discrete numbered step is what the AC ("read at the right point in the
+    orientation order") asks for. Added a parenthetical to step 3 to avoid double-reading.
+    (decided by: claude) [confidence: high]
+  - Resolved the header comment by rewriting (not deleting) its last sentence — kept the cycle-0
+    promotion provenance, changed only the forward-looking clause to a resolved pointer.
+    (decided by: claude) [confidence: high]
+- **Acceptance criteria**:
+  - [x] ROUTE.md is read at the right point in the orientation order (new step 2, before
+        journal/commits)
+  - [x] The header follow-up comment is resolved (forward-looking sentence → resolved note)
+- **Engineer feedback incorporated**: Gearing set to free climb up front.
+- **Learnings**:
+  - Engineer → Claude: None specific to this slice.
+  - Claude → Engineer: The orientation order is a dependency chain ("later items make sense
+    because of earlier ones") — the gate record's *value* is positional: it only frames the
+    journal/commit reads if it's read before them, so where it lands in the list is the design
+    decision, not just that it's present.

--- a/.vine/projects/workflow/routing-foundation/NAVIGATION.md
+++ b/.vine/projects/workflow/routing-foundation/NAVIGATION.md
@@ -830,7 +830,7 @@ cross-references and counts.
 
 ### Slice 17: Command Addition Checklist + count sweeps — Complete
 - **Started**: 2026-06-16 10:34
-- **Commit**: pending
+- **Commit**: 6dd5456
 - **Route**: interactive — `mechanism: n/a`
 - **Actor**: human (Rob + Claude)
 - **Gear**: free-climb
@@ -882,3 +882,59 @@ cross-references and counts.
     to enumerate). ROUTE.md belongs in the first, not the second; conflating them would have
     "fixed" the four-phase story into a wrong five-phase one. The sweep's judgment was *which*
     references are enumerations, not mechanically find-replacing the chain string everywhere.
+
+### Phase-4 boundary verification — Complete
+- **Started**: 2026-06-16 10:42
+- **Commit**: n/a (verification only — no code change)
+- **Route**: interactive — `mechanism: n/a`
+- **Actor**: human (Rob + Claude)
+- **Gear**: free-climb
+- **Approach taken**: Ran the `vine-verification` agent at phase-group scope over Phase 4
+  (Slices 14-17). Result: trellis pass (11/11 + 8 anchors); all four slices' ACs met with
+  file:line evidence; backward-compat (AC-10) fully met (ROUTE.md absent, journal route fields
+  absent, and `## Validation` block absent all degrade to their interactive defaults). No errors.
+  Two observations, both already accounted for in the slice journals, no fix needed:
+  - **(verify.md / ROUTE.md enumeration)** — `.vine/context/verify.md` doesn't list ROUTE.md, but
+    it doesn't enumerate *any* artifact: it carries the command-count reference and points at
+    STATE.md for artifact specs rather than duplicating the list. Consistent by design; recorded
+    in Slice 17's deviation note.
+  - **(README section placement)** — the `## Agents running VINE` section sits after State
+    Artifacts rather than at either spec-suggested seam. Placement deviation with rationale already
+    recorded in Slice 15 (legibility: the section depends on artifacts introduced by that point).
+- **Deviations from spec**: None.
+- **Validation**: pass — `sh .vine/scripts/trellis-check.sh` 11/11 + 8/8 anchors.
+- **Decisions made during implementation**:
+  - Accepted both agent observations as non-issues against the journals' prior reasoning rather
+    than "fixing" them — the verify.md non-enumeration is by design and the README placement is a
+    legibility win, both pre-documented. (decided by: claude) [confidence: high]
+- **Acceptance criteria**:
+  - [x] Phase-group verification run; all Slice 14-17 ACs confirmed met with evidence
+  - [x] Backward compatibility (AC-10) confirmed for every new surface
+- **Engineer feedback incorporated**: None (free climb).
+- **Learnings**:
+  - Engineer → Claude: None specific.
+  - Claude → Engineer: A clean phase-group verification at the *final* group is the lighter
+    pre-flight; evolve's full-feature tier still owns cross-slice integration across all four
+    phases and the deviation/follow-up review. The asymmetry is intentional (verification-tier
+    contract in STATE.md).
+
+### Remaining Work
+- **Incomplete slices**: All 17 slices complete across Phases 1-4 (Phase 4: Slices 14-17 done
+  this session). The full routing-foundation cycle is implemented.
+- **Blockers encountered**: None.
+- **Handoff context for evolve**:
+  - **Phase 4 PR not yet opened.** Slices 14-17 are committed (9baacaf, f6df658, 6983c3f,
+    6dd5456) on `feature/routing-foundation` but unpushed; PROJECT-MAP Phase 4 row is ✅ Complete
+    (no PR). evolve's handoff prep should open the final Phase 4 PR. Prior phases shipped as
+    #94 (P1), #97 (P2), #98 (P3).
+  - **Full-feature verification is evolve's job.** The phase-group check above is the lighter
+    tier; evolve runs the full-feature tier across all four phases and verifies the 10 cycle-level
+    ACs in SPEC.md (not just per-slice).
+  - **No open deviations.** Every slice's "Deviations from spec" is None or a descriptive-hint
+    imprecision explicitly flagged as needing no SPEC annotation (Slices 8, 15, 17) — nothing for
+    evolve to reconcile across SPEC/NAVIGATION.
+  - **Discovered items, all closed in-cycle**: Slice-4 init-template precedence gap (closed at the
+    Phase-1 boundary), Slice-6 CLAUDE.md State Artifact Chain ROUTE.md omission (closed in Slice
+    17). No carried discovered items remain.
+  - **Backlog (out of cycle, for evolve's triage):** journal-check observability, federated
+    knowledge sync (2027), `.vine/knowledge/<domain>.md` (#51, cycle 3) — see SPEC Backlog Updates.

--- a/.vine/projects/workflow/routing-foundation/PROJECT-MAP.md
+++ b/.vine/projects/workflow/routing-foundation/PROJECT-MAP.md
@@ -8,7 +8,7 @@
 |-------|--------|---------|
 | verify | ✅ | 2026-06-14 |
 | inquire | ✅ | 2026-06-14 |
-| navigate | 🚧 | 2026-06-16 |
+| navigate | ✅ | 2026-06-16 |
 | evolve | ⬜ | — |
 
 ### Milestones
@@ -18,4 +18,4 @@
 | Phase 1: Precedence & Validation Foundation | 1-5 | ✅ Shipped | #94 |
 | Phase 2: Eligibility Gate & Route Record | 6-9 | ✅ Complete | #97 |
 | Phase 3: Headless Contract & Journaling | 10-13 | ✅ Shipped | #98 |
-| Phase 4: Docs, Reviewer & Trellis | 14-17 | ⬜ Pending | — |
+| Phase 4: Docs, Reviewer & Trellis | 14-17 | ✅ Complete | — |

--- a/.vine/projects/workflow/routing-foundation/PROJECT-MAP.md
+++ b/.vine/projects/workflow/routing-foundation/PROJECT-MAP.md
@@ -18,4 +18,4 @@
 | Phase 1: Precedence & Validation Foundation | 1-5 | ✅ Shipped | #94 |
 | Phase 2: Eligibility Gate & Route Record | 6-9 | ✅ Complete | #97 |
 | Phase 3: Headless Contract & Journaling | 10-13 | ✅ Shipped | #98 |
-| Phase 4: Docs, Reviewer & Trellis | 14-17 | ✅ Complete | — |
+| Phase 4: Docs, Reviewer & Trellis | 14-17 | ✅ Complete | #100 |

--- a/.vine/projects/workflow/routing-foundation/PROJECT-MAP.md
+++ b/.vine/projects/workflow/routing-foundation/PROJECT-MAP.md
@@ -17,5 +17,5 @@
 |-------|--------|--------|----|
 | Phase 1: Precedence & Validation Foundation | 1-5 | ✅ Shipped | #94 |
 | Phase 2: Eligibility Gate & Route Record | 6-9 | ✅ Complete | #97 |
-| Phase 3: Headless Contract & Journaling | 10-13 | ✅ Complete | #98 |
+| Phase 3: Headless Contract & Journaling | 10-13 | ✅ Shipped | #98 |
 | Phase 4: Docs, Reviewer & Trellis | 14-17 | ⬜ Pending | — |

--- a/.vine/projects/workflow/routing-foundation/PROJECT-MAP.md
+++ b/.vine/projects/workflow/routing-foundation/PROJECT-MAP.md
@@ -9,7 +9,7 @@
 | verify | ✅ | 2026-06-14 |
 | inquire | ✅ | 2026-06-14 |
 | navigate | ✅ | 2026-06-16 |
-| evolve | ⬜ | — |
+| evolve | ✅ | 2026-06-16 |
 
 ### Milestones
 

--- a/.vine/projects/workflow/routing-foundation/SPEC.md
+++ b/.vine/projects/workflow/routing-foundation/SPEC.md
@@ -284,7 +284,7 @@ field correction when a mechanism diverges mid-slice (the #90 wrong-extraction g
 are optional with graceful absence on older journals.
 **Complexity signal**: Medium.
 
-## Phase 4: Docs, Reviewer & Trellis (Slices 14-17) ⬜
+## Phase 4: Docs, Reviewer & Trellis (Slices 14-17) ✅
 Summary: Make the new surfaces discoverable, reviewable, and validated.
 Session boundary: Cycle complete and ready for evolve.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ VINE is a pure-markdown AI-assisted development framework. There is no build ste
 - Load Context Overlays must appear before Load Engineer Profile — this ordering is enforced by `/trellis`
 - Commands are written in second-person instructional markdown ("Scan the project for...", "Present a summary...")
 - Sections use `##` headers for major steps, `###` for substeps; anti-patterns and constraints are called out explicitly
+- When adding to a command, prefer an unnumbered `###` section over renumbering existing steps — renumbering ripples through every `step N` cross-reference (in the command and in `references/STATE.md`), the exact drift `/trellis` Check 10 catches. An unnumbered section also signals "runs once / out of the numbered flow" (e.g. navigate's head-only routing gate)
 - `AskUserQuestion` is preferred for all decision points: max 4 questions per call, max 4 options per question, recommended option first with "(Recommended)" suffix
 - Shared patterns (collaboration stance, profile protocol) live in `.vine/context/shared.md` — commands reference them with "Follow the [Protocol] from shared.md" rather than repeating the full block. This saves ~150 tokens per command invocation. Commands still work without shared.md (graceful fallback).
 - Run `/trellis` to validate command structure and artifact format compliance before submitting changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,10 @@ VINE is a pure-markdown AI-assisted development framework. There is no build ste
 
 ## State Artifact Chain
 
-Features flow through: `CONTEXT.md` → `SPEC.md` → `NAVIGATION.md` → `EVOLUTION.md`
+Features flow through: `CONTEXT.md` → `SPEC.md` → `NAVIGATION.md` → `EVOLUTION.md`. A
+`ROUTE.md` (the routing gate record — verdict, allowlist, constraints, validation baseline)
+optionally joins the chain between `SPEC.md` and `NAVIGATION.md`: `vine:navigate` writes it at
+head when a scope is headless-eligible, and an interactive run omits it (graceful absence).
 
 All live in `.vine/projects/<domain>/<feature-slug>/`. Formats are defined in `references/STATE.md`. Section headings in STATE.md templates use `<!-- required -->` / `<!-- optional -->` HTML comment markers — new sections must include a marker to prevent validation drift.
 

--- a/README.md
+++ b/README.md
@@ -325,6 +325,43 @@ These files are human-readable, git-friendly, and designed to survive session bo
 
 This repo uses VINE on itself — browse [`.vine/projects/`](.vine/projects/) to see real artifacts from completed features. Each resolved project shows how CONTEXT → SPEC → NAVIGATION → EVOLUTION builds up across the four phases.
 
+## Agents running VINE
+
+The same phases a human drives can also run **headless** — an agent executes the work
+unattended, and a reviewer (a person, or another agent) checks it afterward. Headless is
+opt-in and gated: nothing about the normal human-driven flow changes unless you deliberately
+delegate a scope.
+
+**The routing gate.** At the start of `vine:navigate`, before any code is written, VINE decides
+whether a scope is *eligible* to run headless. It checks four things: a validation baseline
+exists (so the agent can verify its own work), the spec carries acceptance criteria, the work is
+independent of anything in flight, and the files it will touch are enumerable. If any is missing,
+the scope stays interactive — the gate only ever **withholds the headless option**; it never
+alters or degrades the human-driven path. For an ordinary interactive session the gate is a
+no-op.
+
+**The gate record.** When a scope is eligible, the decision is written to a `ROUTE.md` in the
+feature directory: the verdict, the **allowlist** of files the work may touch, the constraints
+the agent must honor, the validation baseline that must stay green, and a stamp recording the
+repo state the decision was made against. A headless run is bound by this record — touch only the
+allowlist, keep validation green before each commit, and **escalate anything a human must own**.
+Every decision point in the commands is tagged `human-required` or `default-able`; on a
+human-required decision the agent writes a structured handoff to NAVIGATION.md and stops rather
+than guessing.
+
+**The reviewer.** [`.vine/context/review.md`](.vine/context/review.md) is a recipe for a fresh
+reviewer who wasn't part of the session: how to orient (read ROUTE.md, then the journal, then the
+commits and final files) and what to produce (a verdict, severity-ordered findings, and a draft
+PR description). Everything the reviewer needs lives in durable state, not session memory.
+
+**The agents.** [`agents/`](agents/) ships the agent definitions VINE auto-delegates to by
+description match — `vine-verification` (runs the validation baseline and checks acceptance
+criteria) and `vine-codebase-explorer` (structured codebase exploration). They are the same in an
+interactive or headless run.
+
+See the [State Reference](references/STATE.md) for the ROUTE.md format and the decision-delegation
+and handoff contracts.
+
 ## Engineer Profile
 
 With AI assistance, engineers at every level are moving into unfamiliar domains at increasing speed. A principal exploring a new area of the codebase deserves the same depth of explanation as a junior encountering it for the first time. A junior who's built confidence in their domain deserves the same concise respect as a senior. The profile tracks domain expertise, not seniority — helping juniors to principals grow in areas both new and familiar.

--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ when deciding how much to trust a long or lightly-attended session.
 |------|-------|---------|
 | `CONTEXT.md` | verify | Codebase landscape, tribal knowledge, tech debt |
 | `SPEC.md` | inquire | Feature design, acceptance criteria, work slices |
+| `ROUTE.md` | navigate (head; previewed by inquire) | Routing gate record: verdict, allowlist, constraints, validation baseline — optional, written when a scope is headless-eligible |
 | `NAVIGATION.md` | navigate | Implementation journal, commit-per-slice log |
 | `EVOLUTION.md` | evolve | Verification results, triple evolution report |
 | `PROJECT-MAP.md` | verify (created), all phases (updated) | VINE progress tracker, multi-PR milestone status |


### PR DESCRIPTION
## Summary
Final phase of the routing-foundation cycle (v0.4.0 Cycle 1): make the new routing surfaces
discoverable, reviewable, and validated. Phases 1–3 built the precedence model, the validation
contract, the navigate-head eligibility gate + ROUTE.md record, the headless autonomy contract,
and the journal schema. This phase wires those into the docs, the reviewer's orientation, and
trellis.

## Changes
- **review.md**: a "gate record" step in the reviewer's orientation order — read ROUTE.md
  (verdict, allowlist, constraints, validation baseline, stamp) before the journal/commits, so
  execution is checked against its authorization basis. Graceful when ROUTE.md is absent.
- **README**: an "Agents running VINE" section — the routing gate, the gate record, the reviewer
  role, and the `agents/` directory. One screen, links for depth.
- **trellis**: artifact-tier checks (session-judged, never gate the command-commit stamp) for
  ROUTE.md format (Checks A + E), optional journal route fields (Check D), and the Validation
  block shape (Check F). All skip gracefully when their surface is absent.
- **Cross-reference sweep**: ROUTE.md added to CLAUDE.md's artifact chain and README's State
  Artifacts table; a new State Artifact Addition Checklist in shared.md.

## Decisions Made
- New checks land in trellis's already-unstamped artifact tier, so "don't gate the stamp" needs
  no new mechanism — it falls out of placement (`trellis-check.sh` is unchanged).
- ROUTE.md goes in *enumerating* surfaces (artifact chain, tables) but not *narrative*
  "four phases" prose — it's navigate-internal, not a fifth phase.

## Testing
- `sh .vine/scripts/trellis-check.sh` → 11/11 commands + 8/8 anchors, clean.
- Full-feature verification (evolve tier): all 10 cycle-level ACs MET; backward compatibility
  holds (ROUTE.md / journal route fields / Validation block all degrade to interactive defaults
  when absent).

## Follow-up
Closes #53, #54, #90. The routing-policy half of #55 landed (profile-rework half remains open).
New: #99 (journal-check observability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)