### PR TITLE
triage: consult ROADMAP.md cycle order for next-cycle routing

### DIFF
--- a/.claude/commands/triage.md
+++ b/.claude/commands/triage.md
@@ -47,11 +47,28 @@ Show a concise summary grouped by tier:
 
 Include a one-line count: "X open issues: H high, M medium, L low"
 
+## Consult the Roadmap (if present)
+
+`gh issue list` answers "which open issue is highest priority." It does not answer "what cycle do I build next." When this repo carries a `ROADMAP.md` with a `### Cycle order` table, read it to add that sequence dimension.
+
+This step is **VINE-on-VINE only and degrades gracefully**: check for `ROADMAP.md` first with Glob or `Read`. If it is absent (any repo that isn't this one), skip this section entirely and go straight to Discuss Next Steps — `triage` behaves exactly as the issue-priority tool it is without it. Never treat `ROADMAP.md` as a dependency.
+
+When `ROADMAP.md` is present:
+
+1. Read the `### Cycle order` table and the prose above it (a "Done so far" note records which cycles have shipped). The table columns are `#`, `Cycle`, `Issues`, `Mode`, and a rationale column; issue references appear as `#N` links in the `Issues` column.
+2. Map the open milestone issues from the fetch above to their cycle by matching issue numbers against the `Issues` column. Issues with no cycle match are roadmap-unplaced (still triaged by priority, just not part of the sequence).
+3. Surface the sequence position, not just the priority ranking:
+   - **Current position** — the latest shipped cycle (from the "Done so far" note) and which cycle is next in line.
+   - **Next cycle** — its name, its open issues (with numbers), and the one-line "why this order" rationale from the table.
+   - **Side-track items runnable now** — rows marked as a side-track or "anytime" mode (e.g. a maintenance side-track), with the condition that unblocks them. Call these out separately so a contributor finishing a cycle sees what can run in parallel.
+
+Present this as a short "Roadmap sequence" block after the priority tiers. Keep it to the current position, the next cycle, and any runnable side-track items — do not restate the whole table.
+
 ## Discuss Next Steps
 
 Use `AskUserQuestion` to ask the user what they'd like to do:
 
-- **Pick an issue to work on** — ask which one, then read its full body with `gh issue view <number>` and suggest an approach (which VINE command to start with, or direct implementation for small fixes)
+- **Pick an issue to work on** — ask which one, then read its full body with `gh issue view <number>` and suggest an approach (which VINE command to start with, or direct implementation for small fixes). When a roadmap sequence was surfaced above, lead with the next cycle's issues and any runnable side-track items as the recommended picks
 - **Bulk label/organize** — help apply labels to unlabeled issues
 - **Close stale issues** — identify and suggest closing issues that are outdated
 - **Create a new issue** — help draft one based on conversation context


### PR DESCRIPTION
## Summary
Teaches the contributor `triage` command to read `ROADMAP.md`'s cycle order after fetching
issues, so it can answer "what cycle do I build next?" not just "which open issue is highest
priority." Closes #101.

## Changes
- New `## Consult the Roadmap (if present)` section in `.claude/commands/triage.md`: maps open
  milestone issues to their roadmap cycle, then surfaces the current sequence position, the next
  cycle (name + open issues + the one-line "why this order" rationale), and side-track items
  runnable now.
- One line in Discuss Next Steps so triage leads with the next cycle's issues as recommended picks.

## Why contributor-tier
`ROADMAP.md` is this repo's artifact and does not ship in `create-vine`, so this stays in
`.claude/commands/` (not the shipped product) and degrades gracefully: absent `ROADMAP.md`, the
step is skipped and triage behaves exactly as today. No hard dependency.

## How to test
Run `/triage` in this repo and confirm a "Roadmap sequence" block appears after the priority
tiers; the roadmap logic is pure instructional markdown.

## Provenance
First headless/delegated run under the routing-foundation contract (Cycle 1): bounded to one file,
validated with trellis, committed, stopped for human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)