### PR TITLE
vine-reviewer: add a validation-discovery ladder to the recipe

### DIFF
--- a/agents/vine-reviewer.md
+++ b/agents/vine-reviewer.md
@@ -46,8 +46,20 @@ Read in this order; later items will make sense because of earlier ones:
 - Decisions the actor made on its own authority — especially any it marked lower confidence. Those
   are where your judgment adds the most.
 - Validation claims — re-run cheap checks rather than trusting the report when a command is named and
-  takes seconds.
+  takes seconds (discover the commands via *Discovering Validation Commands* below).
 - Boundary behavior — things the actor flagged but didn't touch. Was restraint right?
+
+## Discovering Validation Commands
+
+When you re-run cheap checks, discover the commands in priority order — don't assume a fixed set:
+
+1. The `## Validation` block in `.vine/context/shared.md` — a fenced YAML contract with optional keys
+   `lint` / `typecheck` / `test` / `test-all` / `build` / `extra`. Run the keys that are present;
+   ignore absent ones. When the block exists it is authoritative.
+2. Prose inference (fallback — no block, or it omits a check): `package.json` scripts, config files
+   (`.eslintrc`, `tsconfig.json`, `pyproject.toml`, `Makefile`), the `.vine/context/*.md` overlays,
+   and named scripts the repo ships (e.g. `.vine/scripts/trellis-check.sh`).
+3. If neither yields commands, there are no automated checks — report that rather than guessing one.
 
 ## What to Produce
 


### PR DESCRIPTION
## What

Adds a short **Discovering Validation Commands** section to `agents/vine-reviewer.md` — a priority-ordered ladder for finding the repo's validation commands when the reviewer re-runs cheap checks: (1) the `## Validation` block in `.vine/context/shared.md`, (2) prose inference from `package.json` scripts, config files, context overlays, and named scripts like `trellis-check.sh`, (3) report "no automated checks" rather than guessing. The existing "re-run cheap checks" bullet now points to it.

## Why

The reviewer recipe told the agent to re-run cheap validation but only named the `## Validation` block as the source — and the VINE repo itself ships no such block, so the instruction dead-ended. A cold-review run recovered by inferring from a shipped script, but the discovery path should be explicit. This brings the reviewer in line with the ladders already in `vine-coder` ("Run validation") and `vine-verification` ("Finding Project Tools").

## How to test

Run `sh .vine/scripts/trellis-check.sh` — stays 11/11. Read the new section in `agents/vine-reviewer.md` and confirm it mirrors the sibling agents' wording.

## Checklist

- [x] Changes are focused on a single concern
- [x] Any new behavior is documented in the command/agent file