### PR TITLE
Add Out-of-Scope Routing recommendation across phases

### DIFF
--- a/.vine/context/shared.md
+++ b/.vine/context/shared.md
@@ -180,6 +180,32 @@ No separate per-feature route artifact is needed: the payload lives in {the tick
 the `## Validation` block}. The PR that comes back is the result; a human or the `vine-reviewer`
 agent (the cold-reviewer role) reviews it before merge — **the review is the leash.**
 
+## Out-of-Scope Routing
+
+The standard recommendation whenever work surfaces that's real but **outside the current
+feature's scope** — an unrelated bug, adjacent tech debt, a refactor that would help but isn't
+this feature. Never silently absorb it (scope creep) or silently drop it (lost work). Surface
+the disposition via `AskUserQuestion` (follow the Interaction Constraints), recommending the
+first route unless the engineer signals otherwise:
+
+- **Backlog** *(default)* — capture it where this repo tracks work: the destination is
+  repo-defined (read Team Context / the phase overlay's ticket workflow; this repo uses GitHub
+  Issues, falling back to `gh issue create`, else leave it in the feature artifact). Give it a
+  standalone title and enough cold-pickup context to act on without the VINE artifacts
+  (Reference Legibility, `references/STATE.md`). Lowest friction; current scope stays intact, and
+  the item earns its own cycle when it's picked up later.
+- **Trigger now (`vine:pair`)** — a small, contained fix you want to handle immediately. Pair is
+  artifact-free (no SPEC needed), so it fits an unrelated discovery as-is; spin a separate
+  session so the current work isn't disturbed.
+- **Drop** — not worth tracking; say so and move on.
+
+Recommend backlog by default; reserve `vine:pair` for the small fix you'll genuinely do now —
+anything larger or fuzzier belongs in the backlog, where it earns its own design cycle. Backlog
+and `vine:pair` are the shipped defaults, not the ceiling: a repo overlay may add routes its
+conventions support — e.g. an autonomous `vine-coder` flow for discoveries that are already
+ticket-ready (bounded, own acceptance criteria, validation contract). VINE owns the recommendation
+and the route set; the routes offered and the backlog destination stay repo-supplied.
+
 ## Collaboration Stance
 
 Internal, not shown to the engineer. Apply this stance in all VINE phases:

--- a/commands/vine/evolve.md
+++ b/commands/vine/evolve.md
@@ -146,9 +146,11 @@ Compile from NAVIGATION.md's "discovered items" and any gaps found during verifi
 
 Suggest concrete backlog items with enough context that someone else could pick them up.
 
-If there are actionable follow-up items (not just "consider someday" notes), offer to create
-tickets. Use `AskUserQuestion` with `multiSelect: true` to let the engineer pick which items
-should become tickets. For each selected item:
+If there are actionable follow-up items (not just "consider someday" notes), route them with the
+**Out-of-Scope Routing** pattern from `.vine/context/shared.md`: most become backlog tickets, but
+a small fix the engineer wants handled now can go straight to a `vine:pair` session. Use
+`AskUserQuestion` with `multiSelect: true` to let the engineer pick which items become tickets.
+For each selected item:
 
 - A title that stands alone (not "follow-up from [feature]")
 - Body with enough context from CONTEXT.md and NAVIGATION.md that someone could pick it up

--- a/commands/vine/init.md
+++ b/commands/vine/init.md
@@ -185,6 +185,29 @@ Apply these to every `AskUserQuestion` call, in any phase:
 - Batch related decisions into one call when possible
 - If a topic needs more than 4 options, split it by category across multiple questions
 
+## Out-of-Scope Routing
+
+The standard recommendation whenever work surfaces that's real but outside the current
+feature's scope (an unrelated bug, adjacent tech debt, a refactor that isn't this feature).
+Never silently absorb it (scope creep) or silently drop it (lost work). Surface the disposition
+via `AskUserQuestion` (follow the Interaction Constraints), recommending the first route unless
+the engineer signals otherwise:
+
+- **Backlog** *(default)* — capture it where this repo tracks work (read Team Context or the
+  phase overlay's ticket workflow; fall back to `gh issue create` when available, else leave it
+  in the feature artifact). Standalone title + enough cold-pickup context to act on without the
+  VINE artifacts. Lowest friction; current scope stays intact, and the item earns its own cycle
+  when it's picked up later.
+- **Trigger now (`vine:pair`)** — a small, contained fix you want to handle immediately. Pair is
+  artifact-free (no SPEC needed), so it fits an unrelated discovery as-is; spin a separate session.
+- **Drop** — not worth tracking; say so and move on.
+
+Recommend backlog by default; reserve `vine:pair` for the small fix you'll genuinely do now.
+Anything larger belongs in the backlog. Backlog and `vine:pair` are the defaults, not the ceiling
+— add routes this repo's conventions support (e.g. an autonomous `vine-coder` flow for
+discoveries that are already ticket-ready). VINE owns the recommendation and the route set; the
+routes offered and the backlog destination stay repo-supplied.
+
 ## Team Context
 <!-- class: policy -->
 
@@ -429,6 +452,8 @@ If `.vine/context/` already exists (from a previous `/vine:init` or manual setup
    - "Collaboration Stance" — if missing, add it (commands now reference this from shared.md)
    - "Engineer Profile Protocol" — if missing, add it
    - "Interaction Constraints" — if missing, add it
+   - "Out-of-Scope Routing" — if missing, add it (commands now reference this pattern from
+     shared.md to route unrelated discoveries: backlog by default, or trigger now)
    - "Validation" — if missing, offer the structured block populated from discovery; declining
      leaves prose inference in place (nothing changes on disk)
 4. Present a diff of what's new vs what's already in the overlays using `AskUserQuestion`:

--- a/commands/vine/inquire.md
+++ b/commands/vine/inquire.md
@@ -225,7 +225,10 @@ Based on everything you've discussed, suggest updates to the project backlog:
 - Items that are now unblocked by this feature
 - Tech debt items deferred from this work
 
-Present these as suggestions. The engineer manages the backlog.
+Present these as suggestions — the engineer manages the backlog. For any item that's actionable
+now rather than someday, apply the **Out-of-Scope Routing** pattern from `.vine/context/shared.md`
+(backlog by default, or a `vine:pair` session for a small fix worth doing now) instead of only
+parking it.
 
 ### 8. Write SPEC.md
 

--- a/commands/vine/navigate.md
+++ b/commands/vine/navigate.md
@@ -501,8 +501,11 @@ The work so far should stand on its own.
 than you. When they suggest a different approach, explore it seriously. When you're unsure,
 say so — the engineer is a resource, not an audience.
 
-**Stay in scope.** If you notice something that should be fixed but isn't in the spec, note it
-in NAVIGATION.md under "discovered items" rather than fixing it.
+**Stay in scope.** If you notice something that should be fixed but isn't in the spec, don't
+fix it inline. Note it in NAVIGATION.md under "discovered items," then apply the **Out-of-Scope
+Routing** pattern from `.vine/context/shared.md` — recommend backlog by default, or, for a small
+fix the engineer wants handled now, a separate `vine:pair` session so the current slice stays
+focused.
 
 ## Phase Completion
 

--- a/commands/vine/verify.md
+++ b/commands/vine/verify.md
@@ -197,6 +197,11 @@ are "not great." Capture them without judgment:
 - Whether it should be addressed now, during the feature work, or later
 - Rough effort estimate if the engineer has a sense
 
+Most of these stay cataloged for inquire to weigh against the feature. But if something is
+clearly unrelated to this feature and worth acting on regardless, apply the **Out-of-Scope
+Routing** pattern from `.vine/context/shared.md` rather than letting it ride — backlog it by
+default, or a `vine:pair` session for a small fix worth doing now.
+
 ### 6. Write CONTEXT.md
 
 Once you've explored enough, produce the context document. This should capture everything you've


### PR DESCRIPTION
## What
Adds a shared **Out-of-Scope Routing** pattern and wires all four phase commands (`verify`, `inquire`, `navigate`, `evolve`) to it. When work surfaces that's real but outside the current feature's scope, the command now surfaces one standard choice — **backlog it** (default) or spin a quick **`vine:pair`** session — instead of each phase handling stray scope its own ad-hoc way.

## Why
Out-of-scope discoveries were handled inconsistently and only at phase boundaries, with no live "handle it now vs. later" prompt. This makes the recommendation standard and consistent across phases. Backlog and `vine:pair` are the shipped defaults, not a ceiling — a repo overlay can add its own routes (e.g. an autonomous flow) where its conventions support it; the backlog destination stays repo-supplied.

Refs #104 — adds another command→`shared.md` section reference for that proposed check to enumerate.

_Touches core phase commands, but additive and backward-compatible: no new artifact, no phase-flow/state-model change, and the reference degrades gracefully when the section is absent._

## How to test
1. During `/vine:navigate`, mention an unrelated bug mid-slice — it offers backlog or `vine:pair` rather than fixing inline.
2. `sh .vine/scripts/trellis-check.sh` → 11/11 commands pass, anchors resolve.

## Checklist
- [x] Changes are focused on a single concern
- [x] New behavior documented in the command files / `shared.md`
- [ ] Tested in an actual VINE cycle — validated via `trellis-check`; not yet run through a live cycle