### PR TITLE
team-layer Phase 1 (#52): .vine.local/ composition model

### DIFF
--- a/.vine/context/shared.md
+++ b/.vine/context/shared.md
@@ -64,10 +64,9 @@ VINE ships the mechanism, not a fixed shape. To make conventions travel with the
 the tracked repo overlay (`.vine/context/shared.md`) and mark anything the team enforces regardless of
 personal preference with `<!-- class: policy -->` (per Overlay Precedence above, the personal
 `.vine.local/` layer cannot weaken a policy section). That pair — tracked `shared.md` plus the policy
-marker — is the whole team layer; no separate team-overlay file or `vine:team` command is needed.
-Distributing those overlays across repos, so an engineer installs the team conventions they belong to,
-is the job of plugin distribution in a later cycle ([#57](https://github.com/moduloMoments/VINE/issues/57):
-overlay distribution as plugins).
+marker — is the whole team layer; no separate team-overlay file or dedicated command is needed. To
+share those overlays across repos today, commit the overlay files your team needs; packaged
+cross-repo distribution is a separate, future concern.
 
 ## Tooling Notes
 

--- a/.vine/context/shared.md
+++ b/.vine/context/shared.md
@@ -57,6 +57,18 @@ Only policy-class sections carry the marker; unmarked means preference. This is 
 resolution rule — the personal-overlay load step, init's upgrade pass, and the reviewer orientation
 reference it rather than restating it.
 
+### Team conventions (recommendation)
+
+Team conventions are **repo-owned, not framework-prescribed** — team structure varies org to org, so
+VINE ships the mechanism, not a fixed shape. To make conventions travel with the project, put them in
+the tracked repo overlay (`.vine/context/shared.md`) and mark anything the team enforces regardless of
+personal preference with `<!-- class: policy -->` (per Overlay Precedence above, the personal
+`.vine.local/` layer cannot weaken a policy section). That pair — tracked `shared.md` plus the policy
+marker — is the whole team layer; no separate team-overlay file or `vine:team` command is needed.
+Distributing those overlays across repos, so an engineer installs the team conventions they belong to,
+is the job of plugin distribution in a later cycle ([#57](https://github.com/moduloMoments/VINE/issues/57):
+overlay distribution as plugins).
+
 ## Tooling Notes
 
 The command and agent inventory lives in the harness's native skill list, not in files — see the Knowledge Boundary rule in `references/STATE.md`. Repo-specific note:
@@ -225,7 +237,7 @@ Internal, not shown to the engineer. Apply this stance in all VINE phases:
 
 ## Engineer Profile Protocol
 
-After loading overlays, check for `.vine/PROFILE.md`. If it exists, read the Domain Expertise
+After loading overlays, check for `.vine.local/PROFILE.md`. If it exists, read the Domain Expertise
 table. Match the feature's domain against the profile's entries.
 
 - **If the domain is in the profile**: Note their level for this session. Use it to calibrate

--- a/.vine/context/shared.md
+++ b/.vine/context/shared.md
@@ -14,9 +14,12 @@ the Overlay Loading Protocol" pulls in.
   they conflict — they are the team's customization of VINE for this codebase. (Precedence
   *between* the overlay layers — shared vs. personal vs. policy — is governed by **Overlay
   Precedence** below; that section is the source of truth and this line does not override it.)
-- **Personal layer.** After reading `shared.md` and the phase overlay, read
-  `.vine/context/shared.local.md` if present and compose it per the **Personal layer** rule in
-  Overlay Precedence. Absent it, nothing changes.
+- **Personal layer.** After reading each repo overlay from `.vine/context/` (`shared.md` and the
+  phase overlay), read its personal counterpart at the mirrored path under the personal root —
+  `.vine.local/context/<name>.md` (e.g. `.vine.local/context/shared.md`,
+  `.vine.local/context/<phase>.md`) — and compose it per the **Personal layer** rule in Overlay
+  Precedence. The personal overlay is distinguished by its root, not a filename suffix (the `.local`
+  suffix is dropped). Absent any personal file, nothing changes.
 - **Legacy fallback (supported through 0.4.x).** If `.vine/context/` doesn't exist but legacy
   `.vine/hooks/` does, read the same files from `.vine/hooks/` instead and nudge once per
   session, no more: "Heads up: this project uses the legacy `.vine/hooks/` directory — run
@@ -33,25 +36,25 @@ minimal behavior, and missing overlays mean the command runs on its built-in def
 ## Overlay Precedence
 
 VINE composes context from command defaults, this shared overlay (`shared.md`), and the
-engineer's personal layer (`shared.local.md`). They resolve as **flat personal-wins with
+engineer's personal layer (`.vine.local/context/`). They resolve as **flat personal-wins with
 policy carve-outs**, mirroring how Claude's own settings resolve — local overrides project,
 except an immutable enterprise-policy ceiling:
 
-- **Preference content** (every unmarked section) is personal-overridable: where `shared.local.md`
-  and `shared.md` conflict, the personal layer wins.
+- **Preference content** (every unmarked section) is personal-overridable: where a personal overlay
+  and its repo counterpart conflict, the personal layer wins.
 - **Policy content** is immutable from the personal layer. A section marked `<!-- class: policy -->`
-  directly under its heading always wins over personal overrides — `shared.local.md` cannot weaken
+  directly under its heading always wins over personal overrides — a personal overlay cannot weaken
   or replace it. Policy sections carry team governance the repo enforces regardless of personal
   preference (CI/CD gates, the team operating model).
 
-**Personal layer (`shared.local.md`).** Each command's *Load Context Overlays* step, after
-reading `shared.md` and the phase overlay, reads `.vine/context/shared.local.md` if present and
-composes it by the rule above — it overrides preference content and is ignored where it would
-override a policy-class section. The file is gitignored (personal scope); absent it, nothing
-changes.
+**Personal layer (`.vine.local/context/`).** Each command's *Load Context Overlays* step, after
+reading a repo overlay (`shared.md`, a phase overlay), reads its personal counterpart at the
+mirrored path `.vine.local/context/<name>.md` if present and composes it by the rule above — it
+overrides preference content and is ignored where it would override a policy-class section. Personal
+overlays live under the gitignored personal root (`.vine.local/`); absent them, nothing changes.
 
 Only policy-class sections carry the marker; unmarked means preference. This is the single
-resolution rule — the `.local` load step, init's upgrade pass, and the reviewer orientation
+resolution rule — the personal-overlay load step, init's upgrade pass, and the reviewer orientation
 reference it rather than restating it.
 
 ## Tooling Notes

--- a/.vine/knowledge/workflow/2026-06-22-anchor-the-personal-root-at-the-repo-shared-across-worktrees.md
+++ b/.vine/knowledge/workflow/2026-06-22-anchor-the-personal-root-at-the-repo-shared-across-worktrees.md
@@ -1,0 +1,81 @@
+# Anchor the .vine.local/ personal root at the repository, shared across worktrees, not at the working directory
+
+## Status
+
+Accepted — 2026-06-22
+Source: workflow/team-layer · Actor: Rob + Claude
+Supersedes: none
+
+## Context
+
+The team-layer cycle (#52) moves all personal/ephemeral VINE state into a gitignored sibling root,
+`.vine.local/` — profile, personal overlays, the `ACTIVE` sentinel, `PAUSE.md`, and local-only
+projects. The Phase 1 contract (`references/STATE.md`) describes it as a sibling root resolved at the
+project root, i.e. relative to the current working directory.
+
+That resolution is wrong for git worktrees and fresh clones, and the failure is silent. Gitignored
+files are not checked out into a `git worktree`, so a worktree session never sees the personal state
+that lives in the main checkout. Observed concretely during this cycle: the main checkout carries a
+real `.vine/PROFILE.md`, but the ~19 worktrees (including the one running this navigate session) have
+no copy — every worktree session ran as if no profile existed, with no depth calibration. Moving the
+state into a gitignored `.vine.local/` inherits the blind spot unchanged and consolidates *more*
+state behind it.
+
+The root cause: personal state was keyed to the **working directory** (`./.vine.local/`) when it
+should be keyed to the **repository**. The worktree case also exposes that "personal state" is two
+scopes, not one:
+
+- **Per-repo / per-developer** — profile, personal overlays, local-only projects, pause notes. Want
+  to be **shared** across every worktree of the repo (you have one expertise profile, not one per
+  branch).
+- **Per-working-tree** — the `ACTIVE` sentinel, whose whole job is "a navigate session is active *in
+  this tree*." Must stay **local**: a shared `ACTIVE` would make the installed hooks in worktree B
+  fire against a session running in worktree A.
+
+A single uniformly-shared `.vine.local/` fixes the profile but breaks `ACTIVE`'s hook scoping; a
+single uniformly-local one (the Phase 1 contract) keeps `ACTIVE` correct but loses the profile. The
+two scopes must resolve to different anchors.
+
+## Decision
+
+Resolve the personal root from git, not from the working directory, and split it by scope:
+
+- **Shared personal root** — anchor `.vine.local/` at the repository's *primary* worktree, found via
+  `git rev-parse --git-common-dir` (identical from every linked worktree; its parent is the main
+  worktree root). Profile, personal overlays, local-only projects, and pause state live there once
+  and are seen identically from every worktree. It remains a visible sibling root at the main
+  checkout.
+- **`ACTIVE` sentinel** — move it *out* of `.vine.local/` into the per-worktree private git dir
+  (`git rev-parse --git-dir` → `.git` in the main tree, `.git/worktrees/<id>/` in a linked worktree).
+  Per-tree, inherently un-committed, and the hooks resolve it the same way, so scoping stays correct.
+
+Commands and hook scripts resolve these anchors rather than assuming a cwd-relative `./.vine.local/`.
+A non-git directory (no `git` available) falls back to the cwd-relative root — the single-checkout
+case is unaffected.
+
+This is folded into **Phase 2 (Discovery & Session Plumbing)** of #52, which already relocates
+`ACTIVE`/`PAUSE` and edits the hook scripts; the `references/STATE.md` `.vine.local/` contract is
+amended there to specify git-anchored resolution and the `ACTIVE`-stays-per-tree split. Phase 1's
+composition model is unchanged — `.vine.local/` at the main checkout is still the correct literal
+path; Phase 2 only adds *how a worktree resolves to it*. Considered and rejected: a `~/.vine/<repo-key>/`
+home outside the repo — it also survives clones, but loses in-repo discoverability and complicates
+local-only projects living next to their code; reach for it only if clone-portability becomes a goal.
+
+## Consequences
+
+- Worktree and main-checkout sessions share one profile / personal-overlay set per repo, so the
+  silent "no profile here" failure disappears. A cold reader of a worktree that lacks a literal
+  `.vine.local/` learns from this record that resolution is git-anchored by design, not missing.
+- `ACTIVE` leaves `.vine.local/`, correcting the conflation of an ephemeral session sentinel with
+  durable personal state; the per-tree git dir is its natural home and keeps the hooks from
+  cross-firing between concurrent worktree sessions.
+- Phase 2 carries a real implementation cost: every command/hook that touches the personal root or
+  `ACTIVE` must resolve via `git rev-parse` (with a non-git fallback) instead of a literal path, and
+  STATE.md's contract is amended. This is the right phase for it — the session plumbing already lives
+  there.
+- Pairs with the deferred gitignore inversion (`2026-06-16-defer-the-vine-gitignore-inversion-to-the-vine-local-work`):
+  the inversion ignores `.vine.local/` at the main checkout, which this resolution model keeps as the
+  one shared personal root, so the two remain coherent.
+- A short-term stopgap exists independent of the redesign: symlink a worktree's `.vine/PROFILE.md`
+  (or `.vine.local/`) to the main checkout's. Used this cycle to unblock the live worktree; not a
+  substitute for git-anchored resolution.

--- a/.vine/projects/workflow/team-layer/CONTEXT.md
+++ b/.vine/projects/workflow/team-layer/CONTEXT.md
@@ -1,0 +1,187 @@
+# Feature Context: Team Layer (#52)
+
+## Date: 2026-06-18
+## Author: Rob + Claude
+
+> Cycle 4 of the v0.4.0 delegation-routing roadmap. The "route stage's policy layering":
+> team conventions that install with the project instead of living in one person's head.
+> Source issue: [#52](https://github.com/moduloMoments/VINE/issues/52). Depends on the cycle-1
+> precedence split and the cycle-2 knowledge layer, both shipped.
+
+### Codebase Landscape
+
+The feature touches five surfaces. Anchors are to the **main checkout** (this worktree mirrors it).
+
+**1. `commands/vine/init.md` — the scaffolding command.** Step structure:
+- `Step 2: Ask About Team Context` (`init.md:61`) — already the "gather what code can't tell you"
+  step, capped at 1-2 question rounds. The natural slot for a solo-vs-team adoption question; the
+  exact question set is left open today (`init.md:63` says use `AskUserQuestion`, no structured call).
+- `Step 3: Generate Context Overlay Files` (`init.md:72`) — embeds the full `shared.md` template
+  (`init.md:80-229`). Relevant template sections: `## Overlay Precedence` (`init.md:111`, defines the
+  `<!-- class: policy -->` marker and "flat personal-wins with policy carve-outs"), `## Team Context`
+  (`init.md:211`, **already `<!-- class: policy -->`** at `init.md:212`, body is a bare placeholder).
+- `Step 6: Gitignore` (`init.md:367`) — target end-state is two root-`.gitignore` lines (`.vine/*` +
+  `!.vine/README.md`); explicitly defers team sharing to manual negations / `git add -f` (`init.md:390`).
+  **No `.vine/.gitignore` concept exists anywhere.**
+- `Step 8: Upgrade Existing Projects` (`init.md:408`) — detects existing `.vine/context/`, runs
+  `### Upgrade Mode` (`init.md:441`) with a "required shared.md sections" checklist (`init.md:449-456`).
+  This is the backward-compatible migration hook the adoption-mode upgrade would extend.
+
+**2. Project discovery across 7 commands + trellis.** Every command that enumerates features does a
+prose "Scan `.vine/projects/` for feature directories" and filters only two things: `.resolved`
+marker files and the `.archive/` subtree. Sites: `status.md:38`, `resume.md:39`, `pause.md:37`,
+`navigate.md:60`, `inquire.md:44`, `evolve.md:42`, plus init's archive sweep (`init.md:587`). Trellis
+is the only one with an explicit glob: `.vine/projects/*/*/` (`trellis.md:261`). The canonical path
+rule is stated in the `shared.md` template (`init.md:135`) and `references/STATE.md:6-11`.
+
+**3. Overlay composition model.** Today two layers compose: `shared.md` (repo) + `shared.local.md`
+(personal, gitignored), resolved by `## Overlay Precedence` (`shared.md:33-55`) as **flat
+personal-wins with a policy-class carve-out** (`<!-- class: policy -->` sections are immutable from
+the personal layer). There is **no third (team/company) layer** — the roadmap wants team context to
+relocate "from a shared.md section to a composable layer" (ROADMAP.md, "Overlay layers and precedence").
+
+**4. Documentation: README.md + references/STATE.md + CLAUDE.md.**
+- `README.md:158-170` "Piloting in an existing project" — global-gitignore-the-whole-`.vine/`
+  starting posture with a *single* solo→team transition sentence (`README.md:170`) that names only
+  `context/` as the team-shared piece.
+- `references/STATE.md` carries the authoritative tracked-vs-untracked contract: `## Committing
+  Artifacts` (`STATE.md:508-530`), the `**Forward references**` block (`STATE.md:484-486`), the
+  `.vine/ACTIVE` "never leaves the machine" guarantee (`STATE.md:255-277`), the Durable-Decisions
+  one-record-per-file rationale that **already cites #52** as the append-only-journal pattern's origin
+  (`STATE.md:409`), and the Filtering Convention (`STATE.md:584-591`).
+- `CLAUDE.md:17-21` — the repo-structure tracked/gitignored bullets.
+
+**5. Conflict-safe conventions (#52 AC4).** Already partly realized: the knowledge layer's
+one-record-per-file design (`STATE.md:402-417`) *is* the append-only/single-writer pattern, explicitly
+sourced to #52. NAVIGATION.md is already append-only-per-slice. The conventions exist in practice;
+#52's job is to **document them once on a shipped surface** and extend them to feature directories.
+
+#### Durable Decisions on record (workflow domain)
+
+Five records under `.vine/knowledge/workflow/`. Two are directly load-bearing here:
+
+- **[defer-the-vine-gitignore-inversion-to-the-vine-local-work](.vine/knowledge/workflow/2026-06-16-defer-the-vine-gitignore-inversion-to-the-vine-local-work.md)** (Accepted 2026-06-16) — keeps the
+  brittle root `.gitignore` deny-then-allowlist for now and **gates the full track-by-default inversion
+  (#108) on `.vine.local/` landing**, so the whole pattern flips at once. #52 is the natural home for
+  that `.vine.local/` work. *Still live and directly governs this cycle's gitignore decisions.*
+- **[evolve-states-the-four-knowledge-homes-referentially](.vine/knowledge/workflow/2026-06-16-evolve-states-the-four-knowledge-homes-referentially.md)** (Accepted 2026-06-16) — establishes the anti-bloat stance
+  (state a shared rule once and reference it, don't physically restructure long command files). The
+  precedent for how team-layer conventions/overlay rules should be documented. *Still live.*
+
+The other three (`cut-the-derived-map-cache`, `decision-delegation-default-able-vs-human-required`,
+`route-md-headless-eligibility-gate`) are background context, not contradicted by this work.
+
+### Current State
+
+- **This repo is already E2-shaped.** `.vine/context/`, `.vine/projects/`, `.vine/knowledge/` are
+  tracked via the root `.gitignore` allowlist (deny `.vine/*`, re-admit each subdir); `PROFILE.md`,
+  `PAUSE.md`, `ACTIVE`, `*.local.md` stay gitignored. So "tracked-by-default" is *partly already done
+  here* — but as a brittle allowlist, not the clean inversion #108 envisions.
+- **The personal overlay layer already shipped** (cycle 1): `shared.local.md` + `## Overlay
+  Precedence`. #52's overlay-composition half builds on a working two-layer model.
+- **`## Team Context` is already a policy-class section** in `shared.md` (`init.md:211-214`,
+  `shared.md:276`) — the policy infrastructure for team governance exists; what's missing is the
+  adoption-mode question that *populates* it richly and/or a separate composable team layer.
+- **No solo/team mode branch exists** in init (the words "solo"/"single-writer" appear nowhere in
+  init.md / README.md / STATE.md). No `.vine/projects/.local/`, no `.vine.local/`, no `.vine/.gitignore`.
+
+### Edge Cases & Tribal Knowledge
+
+- **The issue predates the decisions that reshape it.** #52's body (2026-06-10, reframe 2026-06-11)
+  specifies `.vine/projects/.local/` (a subdirectory) + a scaffolded `.vine/.gitignore`. But
+  `STATE.md:484-486` (written later) specifies a **`.vine.local/` *sibling root*** mirroring `.vine/`'s
+  structure — a different architecture for the same goal. **This mismatch is the central design
+  decision for inquire** (see Open Questions). Treat the issue ACs as intent, not letter.
+- **The gitignore inversion is deliberately deferred and coupled to this cycle.** Per the knowledge
+  record, #108 (track-by-default inversion) was held *specifically* to flip alongside `.vine.local/`.
+  If `.vine.local/` lands here, #108's inversion can/should ride with it — that's the "flip in one
+  coherent move" the record protects. Doing the sibling-root without the inversion would be the
+  half-migration the record warns against.
+- **`.vine/ACTIVE` has a hook-safety guarantee not to disturb.** It's gitignored, "never leaves the
+  machine," and hooks treat its `feature:` path as opaque (`STATE.md:257,265`). A `.vine.local/`
+  project's ACTIVE path must still be written truthfully by navigate (`navigate.md:83` currently
+  hardcodes the `.vine/projects/...` template) — but hooks already tolerate arbitrary paths, so the
+  risk is in the *writing* command, not the hooks.
+- **`git check-ignore -q .vine/projects`** is the commit-or-skip test in verify/inquire
+  (`verify.md:331`, `inquire.md:314`). It checks the `projects/` root. A model where the shared tree is
+  tracked but personal projects are gitignored needs a **per-path** ignore check, or it will
+  misclassify personal projects as committable.
+- **Discovery must learn one new exclusion (or one new inclusion).** Whichever path wins, the
+  Filtering Convention (`STATE.md:584-591`) and 7 prose scan sites change together — a `.vine.local/`
+  sibling root means commands scan *two* roots; a `.vine/projects/.local/` subdir means commands
+  *exclude* it from the shared scan and add it back when the engineer is in personal mode.
+- **Precedence is currently two-layer flat.** Adding a team/company layer means deciding where it sits
+  relative to repo and personal: the roadmap's rule-class split says preference-type rules resolve
+  personal-wins, policy-type rules resolve company-wins (`ROADMAP.md`, "Precedence on conflict"). The
+  policy-class marker already exists; a *team* layer needs a file/composition story the two-layer model
+  doesn't yet have.
+- **Multiple teams, not a binary (maintainer steer, 2026-06-18).** An engineer/repo can belong to more
+  than one team (e.g. platform *and* payments). So the model is not solo-vs-one-team — it's: init seeds
+  *one* team layer, and a **separate add/update-team flow** composes *additional* team layers over time.
+  This means team overlays are plural and named (e.g. `team-<name>.md` or a `teams/` dir), the
+  composition resolves N team layers + repo + personal (precedence across *sibling* team layers is a new
+  question the two-layer model never faced), and "add/update a team" needs a home — a new command, an
+  init re-run sub-mode, or part of the upgrade pass. Connects to plugin distribution (#57): each team
+  layer may arrive as its own plugin, so an engineer installs the team plugins they belong to.
+- **Team overlay distribution is the plugin cycle's job (#57), which comes *after* this one.** #52's
+  AC referencing "distributed as plugin content" can't fully land here — inquire must split what lands
+  now (the layer + composition + precedence + local/shared mechanics) from what defers to #57
+  (distribution/propagation).
+
+### Tech Debt in Affected Areas
+
+- **Brittle root `.gitignore`** (deny-then-allowlist): every new tracked `.vine/` subdir needs its own
+  negation or it silently vanishes — the failure mode the gitignore-inversion record documents. In
+  scope to *fix* here if `.vine.local/` lands (resolves #108); out of scope to touch otherwise (the
+  record says don't half-migrate).
+- **README "piloting" guidance is thin and slightly stale** — one transition sentence naming only
+  `context/`. #52 explicitly calls for replacing it with a solo→team graduation path; fold the fix into
+  this cycle rather than backlogging.
+- **Prose-only project discovery** (no shared filter helper) means the `.local` rule must be restated
+  at 7+ sites. Consistent with how VINE works today (prose instructions), but a candidate for the
+  "state once, reference" pattern from the referential-homes record.
+
+### Documentation Gaps
+
+- `references/STATE.md` `**Forward references**` (`STATE.md:484-486`) will move from "backlog idea" to
+  implemented — needs to become the real `.vine.local/` (or `.local`) contract.
+- `## Committing Artifacts` (`STATE.md:508-530`) names "a future `.vine.local/` root" — must be
+  formalized or superseded by whatever path inquire picks.
+- README "Piloting" section (`README.md:158-170`) → solo→team graduation path + local-project escape
+  hatch.
+- `CLAUDE.md:17-21` tracked/gitignored bullets → add the team layer + local-project + any `.vine.local/`.
+- The `.vine/README.md` scaffold template (`init.md:281-292` table + forward-looking #52 block at
+  `init.md:349-358`) → reflect the now-real team layer.
+- `references/STATE.md` Command/State Artifact Addition Checklists (`shared.md:72-90`) — if a new
+  overlay file or directory convention is added, these checklists govern the ripple.
+
+### Open Questions
+
+1. **`.vine.local/` sibling root vs `.vine/projects/.local/` subdirectory** — the central architecture
+   decision. The post-issue durable decisions favor the **sibling root** (`STATE.md:484-486`); the
+   issue body says subdirectory. Inquire must pick one and reconcile/supersede the loser. (Lean:
+   sibling root, since it's the recorded direction and unblocks the clean #108 inversion — but that's
+   inquire's call.)
+2. **Does the gitignore inversion (#108) ride this cycle?** The knowledge record gates #108 on
+   `.vine.local/`. If we build `.vine.local/`, do we also flip the root `.gitignore` to track-by-default
+   here (one coherent move, per the record), or land `.vine.local/` first and flip in a follow-up?
+3. **Team layer as composable named overlays vs enriched policy-class `## Team Context`** — given
+   multiple-teams (above), does team context become a set of named composable overlays (e.g.
+   `team-<name>.md` or `context/teams/`) each with a precedence slot, or stay a richer policy-class
+   section in `shared.md` for now with the composable layer deferred to plugin (#57)? If plural overlays,
+   how do *sibling* team layers resolve against each other on conflict (declared order? all policy-class
+   company-wins, so collisions must be rare by construction?)?
+3b. **Home for the add/update-team flow** — init seeds the first team; adding/updating *additional*
+   teams later needs a home. Options: a new `vine:team` command, an init re-run sub-mode, or an extension
+   of init's Upgrade Mode. Whichever is chosen must honor the backward-compat gate and the
+   Command Addition Checklist (`shared.md:72-78`) if it's a new command.
+4. **Where's the solo/team line at scaffold time?** What exactly does team mode scaffold differently
+   (a `.vine/.gitignore`? richer Team Context? the `.vine.local/` root)? And does this repo (already
+   E2-shaped) need anything, or is it the worked example?
+5. **Per-feature visibility mechanism** — where does the team-shared-vs-local-only choice live: a
+   prompt in `vine:verify` at project creation (the only command that *creates* projects), and how does
+   `evolve` offer local→shared promotion?
+6. **Backward-compat migration** — what does init's upgrade pass offer an existing solo `.vine/`, and
+   how do we guarantee declining changes nothing (the #58 rename-fallback pattern the roadmap mandates)?
+7. **Scope split vs #57** — draw the line between what team-layer ships now and what plugin distribution
+   (#57) carries, so neither cycle blocks the other.

--- a/.vine/projects/workflow/team-layer/NAVIGATION.md
+++ b/.vine/projects/workflow/team-layer/NAVIGATION.md
@@ -164,3 +164,11 @@ need — the personal-layer convention never shipped (see Slice 2 decision). Dec
   - **Slice 10 docs-sweep deferrals** (left bare on purpose this phase): init.md's `.vine/README.md`
     scaffold (`init.md` ~292/368 + the `shared.local.md` scaffold lines ~302-362), and shared.md's
     gitignore-tracking note (~line 70/82).
+  - **Worktree resolution (Phase 2 — design added 2026-06-22)**: gitignored personal state is invisible
+    to git worktrees/clones (confirmed live — the main checkout's `.vine/PROFILE.md` was unseen by this
+    worktree session). Phase 2 must resolve the personal root from git, not cwd: shared root (profile,
+    overlays, local projects, pause) via `git rev-parse --git-common-dir`; `ACTIVE` to the per-worktree
+    git dir via `git rev-parse --git-dir` (so hooks don't cross-fire); non-git fallback = cwd. Full
+    rationale in knowledge ADR `2026-06-22-anchor-the-personal-root-at-the-repo-shared-across-worktrees`;
+    SPEC Phase 2 summary annotated. Extends Slices 4-5; amend STATE.md's contract there. Stopgap applied
+    this session: symlinked this worktree's `.vine/PROFILE.md` → main checkout.

--- a/.vine/projects/workflow/team-layer/NAVIGATION.md
+++ b/.vine/projects/workflow/team-layer/NAVIGATION.md
@@ -51,7 +51,7 @@ project is done") rather than a transitional note — simplifying the section to
 
 ### Slice 2: Overlay composition reads the personal root — Complete
 **Started**: 2026-06-22 10:25
-**Commit**: pending
+**Commit**: e28a5c8
 **Gear**: walk-me-through
 **Approach taken**: Updated the Overlay Loading Protocol (Personal layer bullet) and Overlay
 Precedence (intro, the two conflict bullets, the Personal layer paragraph, the closing
@@ -93,6 +93,49 @@ loader fallback was added.
   - Claude → Engineer: `shared.md` and init.md's embedded template must move in lockstep; the
     personal layer generalizes cleanly from "one file `shared.local.md`" to "any overlay's mirrored
     counterpart under `.vine.local/context/`".
+
+### Slice 3: Profile loader path + team recommendation note — Complete
+**Started**: 2026-06-22 10:45
+**Commit**: pending
+**Gear**: walk-me-through
+**Approach taken**: Relocated the engineer-profile path `.vine/PROFILE.md` → `.vine.local/PROFILE.md`
+across every functional site: the read protocol (`shared.md` Engineer Profile Protocol, `status.md`
+Load Engineer Profile, `init.md`'s embedded protocol), the write/create sites (`verify.md` domain-add,
+`evolve.md` Update Engineer Profile × create/update/write, `init.md` Upgrade-Mode existence check), the
+routing-tree pointer + completion-summary line in `evolve.md`, and the init completion message. Added a
+`### Team conventions (recommendation)` subsection to `shared.md`'s Overlay Precedence (mirrored in
+init.md's embedded template): team conventions are repo-owned — put them in the tracked `shared.md` and
+mark governance `<!-- class: policy -->`; no `vine:team` command or separate team-overlay file; plugin
+distribution is #57.
+**Deviations from spec**: None — but a scope clarification worth recording (AC intent over letter):
+AC3 names only the profile *reader*, yet no later slice moves the profile *writers*. Moving only the
+read path would break the profile (written to `.vine/`, read from `.vine.local/`), so this slice moves
+all functional read+write+existence sites together. Deferred to Slice 9/10 (deliberately, not missed):
+the bare-`PROFILE.md` mentions in init.md's `.vine/README.md` scaffold (init.md:292, 368) and the repo
+gitignore-tracking note (shared.md:70) — those describe the directory/gitignore model the flip changes.
+**Validation**: pass — `/trellis` engine green (11/11 commands, 8 cross-ref anchor pairs;
+`.vine/.trellis-ok` stamped pass). Same two pre-existing allowlisted `.vine/hooks/` warnings, unrelated.
+AC3 confirmed: loader reads `.vine.local/PROFILE.md`, absent → unchanged default-depth behavior; the
+team recommendation glosses #57 (reads without dereferencing).
+**Decisions made during implementation**:
+  - Move profile write paths (verify/evolve) in this slice, not just the reader, for read/write
+    coherence — intent over letter, since no other slice covers them (decided by: claude; confidence: high)
+  - File-wide swap of the full path `.vine/PROFILE.md` (backticked + the two non-backticked output
+    strings), leaving bare `PROFILE.md` scaffold/gitignore mentions for the docs sweep — the bare/full
+    split happens to map exactly onto the functional/cosmetic boundary (decided by: claude; confidence: high)
+  - Home the team recommendation under Overlay Precedence (not Team Context), so it sits with the
+    layering/policy-marker explanation it builds on and Slice 10's README can point to it (decided by:
+    claude; confidence: medium)
+**Acceptance criteria**:
+  - [x] AC3 — profile loader reads `.vine.local/PROFILE.md`; absent → no prompt/warning, default depth
+  - [x] Team recommendation present in shared.md + init.md embedded template, reads without
+    dereferencing (Reference Legibility — #57 glossed)
+**Engineer feedback incorporated**: None beyond the gear choice; approach matched the preview.
+**Learnings**:
+  - Engineer → Claude: (none new this slice)
+  - Claude → Engineer: When a path moves, the read and write sites are one atomic unit — a slice that
+    moves only the reader silently breaks the feature; the SPEC's per-slice file lists are a guide, not
+    a hard partition when correctness spans them.
 
 ### Handoff note for Slice 9 (init Upgrade Mode)
 Upgrade Mode should offer to relocate a legacy `.vine/context/*.local.md` → `.vine.local/context/*.md`

--- a/.vine/projects/workflow/team-layer/NAVIGATION.md
+++ b/.vine/projects/workflow/team-layer/NAVIGATION.md
@@ -3,7 +3,7 @@
 
 ### Slice 1: Formalize the `.vine.local/` contract in STATE.md — Complete
 **Started**: 2026-06-22 08:40
-**Commit**: pending
+**Commit**: 3139119
 **Gear**: walk-me-through
 **Approach taken**: Promoted `.vine.local/` from the `**Forward references**` backlog placeholder
 to a real contract in `references/STATE.md`. Added a "The two roots" subsection under Directory
@@ -48,3 +48,53 @@ project is done") rather than a transitional note — simplifying the section to
   - Claude → Engineer: The "state the rule once, reference it" (referential-homes) stance applies
     cleanly here — the two-root scan and per-path commit test each get a single authoritative home in
     STATE.md that later slices (4, 6) point at instead of restating.
+
+### Slice 2: Overlay composition reads the personal root — Complete
+**Started**: 2026-06-22 10:25
+**Commit**: pending
+**Gear**: walk-me-through
+**Approach taken**: Updated the Overlay Loading Protocol (Personal layer bullet) and Overlay
+Precedence (intro, the two conflict bullets, the Personal layer paragraph, the closing
+resolution-rule line) in `.vine/context/shared.md`, and mirrored the same change in
+`commands/vine/init.md`'s embedded shared.md template. The personal layer now reads from
+`.vine.local/context/<name>.md` — the mirrored path under the personal root, `.local` suffix
+dropped — generalized so any repo overlay (`shared.md` and the phase overlays) can have a personal
+counterpart, not just `shared.local.md`. Policy-class carve-out unchanged; no-op when no personal
+file exists.
+**Deviations from spec**: None. Scoped to shared.md + init.md's embedded template. The
+README-scaffold `shared.local.md` mentions in init.md (lines ~290-350) are deferred to Slice 10's
+documentation sweep, per the SPEC's file assignment.
+**Validation**: pass — `/trellis` engine green (11/11 commands, 8 cross-ref anchor pairs;
+`.vine/.trellis-ok` stamped pass). Two pre-existing allowlisted `.vine/hooks/` legacy warnings
+(init.md:104-105) are unrelated. AC2 confirmed by inspection: composition reads the new path, policy
+carve-out preserved, absent personal files is a no-op.
+**Decisions made during implementation**:
+  - Loader reads the NEW path only — no legacy `.vine/context/<name>.local.md` fallback. The
+    `shared.local.md` personal-layer convention never shipped: at tag v0.3.0 (latest published
+    release) the shipped `init.md` has zero `shared.local`/Overlay-Precedence references, so it
+    landed on `main` post-release. No downstream population to stay backward-compatible with; init
+    Upgrade Mode (Slice 9) relocates it for `main`-trackers as a courtesy, not a compat requirement
+    (decided by: engineer — after confirming the convention is unshipped; confidence: high)
+  - Defer init.md's README-scaffold personal-layer mentions to Slice 10 rather than pull them
+    forward, keeping the documentation-sweep PR coherent. The transient inconsistency between init's
+    embedded template (updated) and its README scaffold (not yet) is `main`-only and
+    contributor-visible only (decided by: claude; confidence: medium)
+**Acceptance criteria**:
+  - [x] AC2 — personal overlay read from `.vine.local/context/<name>.md` composed over the repo
+    overlay at `.vine/context/<name>.md`, policy-class carve-out preserved; absent personal files →
+    no change in behavior
+**Engineer feedback incorporated**: On backward-compat, the engineer asked whether the convention
+shipped in the last version (directing: migrate via init upgrade path if it had). It hadn't, so no
+loader fallback was added.
+**Learnings**:
+  - Engineer → Claude: Check whether a convention actually shipped in a released version before
+    building backward-compat machinery — an unshipped convention needs no fallback, only a migration
+    courtesy for source-trackers.
+  - Claude → Engineer: `shared.md` and init.md's embedded template must move in lockstep; the
+    personal layer generalizes cleanly from "one file `shared.local.md`" to "any overlay's mirrored
+    counterpart under `.vine.local/context/`".
+
+### Handoff note for Slice 9 (init Upgrade Mode)
+Upgrade Mode should offer to relocate a legacy `.vine/context/*.local.md` → `.vine.local/context/*.md`
+(suffix dropped) for repos tracking `main`. This is a courtesy migration, not a shipped-version compat
+need — the personal-layer convention never shipped (see Slice 2 decision). Declining must change nothing.

--- a/.vine/projects/workflow/team-layer/NAVIGATION.md
+++ b/.vine/projects/workflow/team-layer/NAVIGATION.md
@@ -96,7 +96,7 @@ loader fallback was added.
 
 ### Slice 3: Profile loader path + team recommendation note — Complete
 **Started**: 2026-06-22 10:45
-**Commit**: pending
+**Commit**: df64d3b
 **Gear**: walk-me-through
 **Approach taken**: Relocated the engineer-profile path `.vine/PROFILE.md` → `.vine.local/PROFILE.md`
 across every functional site: the read protocol (`shared.md` Engineer Profile Protocol, `status.md`
@@ -141,3 +141,26 @@ team recommendation glosses #57 (reads without dereferencing).
 Upgrade Mode should offer to relocate a legacy `.vine/context/*.local.md` → `.vine.local/context/*.md`
 (suffix dropped) for repos tracking `main`. This is a courtesy migration, not a shipped-version compat
 need — the personal-layer convention never shipped (see Slice 2 decision). Declining must change nothing.
+
+### Remaining Work
+- **Incomplete slices**: Phase 1 (Slices 1-3) complete and committed (3139119, e28a5c8, df64d3b).
+  Phases 2-3 (Slices 4-10) remain — a fresh session each, per the multi-PR plan.
+- **Blockers encountered**: None.
+- **Handoff context**:
+  - **Phase-group verification (Phase 1)**: trellis green; AC1/AC2/AC3/AC6/AC7 all met. The
+    `vine-verification` agent flagged `evolve.md:64` (`delete .vine/ACTIVE`) as mismatching STATE.md's
+    `.vine.local/ACTIVE`. **Not a Phase 1 gap** — deferred to Slice 5. Direct check confirmed the ACTIVE
+    *machinery* is uniformly `.vine/ACTIVE` across all commands + hook scripts (navigate writes it,
+    pause/navigate/evolve delete the same path, journal-check.sh/run-tests.sh read it), so the runtime
+    is self-consistent; only STATE.md's contract documents the end-state. Fixing `evolve.md:64` in
+    isolation now would BREAK it (delete the wrong path while navigate still writes the old one).
+  - **Slice 5 (Phase 2) ACTIVE-relocation checklist** — move all of these from `.vine/ACTIVE` →
+    `.vine.local/ACTIVE` together: `navigate.md:79` (writer) + `:384/:416/:478/:557` (leave/delete),
+    `pause.md:100` (delete), `evolve.md:64` (delete), `journal-check.sh:12` (+ line 4 comment, line 63
+    escape-hatch message), `run-tests.sh:35`. Same slice relocates PAUSE.md to `.vine.local/projects/...`.
+  - **PR 1 reviewer note**: STATE.md documents the `.vine.local/` end-state (ACTIVE/PAUSE/PROFILE/
+    gitignore) ahead of the command + hook machinery, which relocates in Phases 2-3. This is the
+    intended "contract leads implementation" phasing (maintainer-directed in Slice 1), not drift.
+  - **Slice 10 docs-sweep deferrals** (left bare on purpose this phase): init.md's `.vine/README.md`
+    scaffold (`init.md` ~292/368 + the `shared.local.md` scaffold lines ~302-362), and shared.md's
+    gitignore-tracking note (~line 70/82).

--- a/.vine/projects/workflow/team-layer/NAVIGATION.md
+++ b/.vine/projects/workflow/team-layer/NAVIGATION.md
@@ -1,0 +1,50 @@
+# Navigation Log: Personal/Local Layer (#52)
+## Date: 2026-06-22
+
+### Slice 1: Formalize the `.vine.local/` contract in STATE.md — Complete
+**Started**: 2026-06-22 08:40
+**Commit**: pending
+**Gear**: walk-me-through
+**Approach taken**: Promoted `.vine.local/` from the `**Forward references**` backlog placeholder
+to a real contract in `references/STATE.md`. Added a "The two roots" subsection under Directory
+Structure (the canonical contract home, top of file) defining the shared `.vine/` vs personal
+`.vine.local/` split: sibling root mirroring `.vine/`'s structure, what it holds (personal overlays,
+`.vine.local/PROFILE.md`, `.vine.local/ACTIVE`, PAUSE under `.vine.local/projects/...`, local-only
+projects), the gitignored-entirely guarantee, and the location-based (not suffix-based) distinguisher.
+Relocated every `.vine/ACTIVE` (6 refs), `.vine/PROFILE.md` (2 refs), and the PAUSE.md path to their
+`.vine.local/` end-state. Rewrote `## Committing Artifacts` to describe the per-path `git check-ignore`
+commit test, and `### Filtering Convention` to state the two-root scan rule once (for Slice 4's scan
+sites to reference). Removed the graduated Forward-references placeholder.
+**Deviations from spec**: None. All Slice 1 ACs (AC1, AC6, AC7) met with only `references/STATE.md`
+touched, matching the slice's stated file list.
+**Validation**: pass — `sh .vine/scripts/trellis-check.sh` exit 0 (11/11 commands pass, 8 cross-ref
+anchor pairs resolve). No markdownlint config or test suite exists in this repo (pure markdown), so
+trellis-check is the only mechanical gate. Pre-existing `init.md` legacy-`.vine/hooks/` warning is
+unrelated to this slice.
+**Decisions made during implementation**:
+  - Document STATE.md at its finished end-state with no transitional hedging (e.g. `rm .vine.local/ACTIVE`
+    escape hatch written to the target even though navigate's writer relocates in Slice 5): STATE.md is
+    the contributor-only contract reference and already documents conventions ahead of implementation
+    (decided by: engineer — surfaced via AskUserQuestion; confidence: high)
+  - Consolidate ALL STATE.md path-relocations (including the PROFILE.md and PAUSE.md section mentions
+    that Slices 3/5 otherwise touch in command files) into this slice, so STATE.md is internally
+    consistent in one move. Slices 3 and 5 therefore touch only shared.md / command files / hook scripts,
+    not STATE.md — consistent with their stated file lists, which never claimed STATE.md (decided by:
+    claude; confidence: high)
+  - Home the contract in Directory Structure (a "The two roots" subsection) rather than a new top-level
+    section, keeping doc growth modest on an already-600+-line file (decided by: claude; confidence: medium)
+**Acceptance criteria**:
+  - [x] AC1 — `.vine.local/` documented as a real contract (structure mirrors `.vine/`, what it holds,
+    gitignored-entirely guarantee); Forward-references placeholder removed
+  - [x] AC6 — Filtering Convention states the two-root scan once, framed as the single referenced home
+  - [x] AC7 — per-path `git check-ignore` commit test described (specific feature dir, not the root)
+  - [x] Artifact-template `<!-- required -->` / `<!-- optional -->` markers unchanged
+**Engineer feedback incorporated**: On the ACTIVE-wording decision, the engineer directed documenting
+the finished end-state ("if we are only updating state, just update it to what it will be when this
+project is done") rather than a transitional note — simplifying the section to its target form.
+**Learnings**:
+  - Engineer → Claude: STATE.md is a contract/reference doc — describe the finished design, not the
+    in-flight transitional state; the per-PR implementation lag is expected and the doc leads it.
+  - Claude → Engineer: The "state the rule once, reference it" (referential-homes) stance applies
+    cleanly here — the two-root scan and per-path commit test each get a single authoritative home in
+    STATE.md that later slices (4, 6) point at instead of restating.

--- a/.vine/projects/workflow/team-layer/NAVIGATION.md
+++ b/.vine/projects/workflow/team-layer/NAVIGATION.md
@@ -161,9 +161,19 @@ need — the personal-layer convention never shipped (see Slice 2 decision). Dec
   - **PR 1 reviewer note**: STATE.md documents the `.vine.local/` end-state (ACTIVE/PAUSE/PROFILE/
     gitignore) ahead of the command + hook machinery, which relocates in Phases 2-3. This is the
     intended "contract leads implementation" phasing (maintainer-directed in Slice 1), not drift.
-  - **Slice 10 docs-sweep deferrals** (left bare on purpose this phase): init.md's `.vine/README.md`
-    scaffold (`init.md` ~292/368 + the `shared.local.md` scaffold lines ~302-362), and shared.md's
-    gitignore-tracking note (~line 70/82).
+  - **Shipped-command ref hygiene (done post-Phase-1, in PR #122)**: per a maintainer directive,
+    removed all VINE-internal references that shouldn't ship to downstream users — the `vine:team`
+    command (never built), the issue links #57/#52/#56, and the README scaffold's "on the roadmap /
+    not yet shipped" forward-looking block (collapsed to shipped-only "Team distribution" guidance).
+    Also corrected the never-shipped `shared.local.md` convention references in init's customize
+    bullet + the team distribution block to `.vine.local/context/`. Mirrored the team-recommendation
+    fix into `.vine/context/shared.md`.
+  - **Slice 10 docs-sweep deferrals** (remaining): the README scaffold's directory **table**
+    (`init.md` ~302/304/306 — the `shared.local.md` / `PROFILE.md` / `ACTIVE`,`PAUSE.md` rows) needs
+    the two-root rework, gated on Phase 2's final locations (per the worktree ADR, `ACTIVE` lands in
+    the per-worktree git dir, NOT `.vine.local/` — so don't bake `.vine.local/ACTIVE` into the table).
+    Plus shared.md's gitignore-tracking note (~line 70/82), CLAUDE.md, README.md, and STATE.md's
+    surfaces per the State Artifact Addition Checklist.
   - **Worktree resolution (Phase 2 — design added 2026-06-22)**: gitignored personal state is invisible
     to git worktrees/clones (confirmed live — the main checkout's `.vine/PROFILE.md` was unseen by this
     worktree session). Phase 2 must resolve the personal root from git, not cwd: shared root (profile,

--- a/.vine/projects/workflow/team-layer/NAVIGATION.md
+++ b/.vine/projects/workflow/team-layer/NAVIGATION.md
@@ -168,12 +168,17 @@ need — the personal-layer convention never shipped (see Slice 2 decision). Dec
     Also corrected the never-shipped `shared.local.md` convention references in init's customize
     bullet + the team distribution block to `.vine.local/context/`. Mirrored the team-recommendation
     fix into `.vine/context/shared.md`.
-  - **Slice 10 docs-sweep deferrals** (remaining): the README scaffold's directory **table**
-    (`init.md` ~302/304/306 — the `shared.local.md` / `PROFILE.md` / `ACTIVE`,`PAUSE.md` rows) needs
-    the two-root rework, gated on Phase 2's final locations (per the worktree ADR, `ACTIVE` lands in
-    the per-worktree git dir, NOT `.vine.local/` — so don't bake `.vine.local/ACTIVE` into the table).
+  - **Slice 10 docs-sweep deferrals** (remaining): the WHOLE `.vine/README.md` scaffold in init.md
+    is currently split-brained on the personal layer and must be reworked as one unit — both the
+    overlay-precedence **prose** (the `shared.local.md` lines ~302/307/315/318, left as-is this phase)
+    AND the directory **table** (`PROFILE.md` / `ACTIVE`,`PAUSE.md` rows ~304/306). The post-Phase-1
+    ref-hygiene pass updated only the customize bullet + team-distribution block to `.vine.local/`,
+    so the scaffold now names both conventions — Slice 10 must close the entire block, not just the
+    table. Gated on Phase 2's final locations (per the worktree ADR, `ACTIVE` lands in the
+    per-worktree git dir, NOT `.vine.local/` — don't bake `.vine.local/ACTIVE` into the table).
     Plus shared.md's gitignore-tracking note (~line 70/82), CLAUDE.md, README.md, and STATE.md's
-    surfaces per the State Artifact Addition Checklist.
+    surfaces per the State Artifact Addition Checklist. (Surfaced by the cold vine-reviewer pass on
+    PR #122.)
   - **Worktree resolution (Phase 2 — design added 2026-06-22)**: gitignored personal state is invisible
     to git worktrees/clones (confirmed live — the main checkout's `.vine/PROFILE.md` was unseen by this
     worktree session). Phase 2 must resolve the personal root from git, not cwd: shared root (profile,

--- a/.vine/projects/workflow/team-layer/PROJECT-MAP.md
+++ b/.vine/projects/workflow/team-layer/PROJECT-MAP.md
@@ -1,0 +1,12 @@
+# Project Map: Team Layer (#52)
+## Feature: .vine/projects/workflow/team-layer
+## Created: 2026-06-18
+
+### VINE Progress
+
+| Phase | Status | Updated |
+|-------|--------|---------|
+| verify | ✅ | 2026-06-18 |
+| inquire | ⬜ | — |
+| navigate | ⬜ | — |
+| evolve | ⬜ | — |

--- a/.vine/projects/workflow/team-layer/PROJECT-MAP.md
+++ b/.vine/projects/workflow/team-layer/PROJECT-MAP.md
@@ -15,6 +15,6 @@
 
 | Phase | Slices | Status | PR |
 |-------|--------|--------|----|
-| Phase 1: Composition Model | 1-3 | 🚧 Active | — |
+| Phase 1: Composition Model | 1-3 | ✅ Complete | — |
 | Phase 2: Discovery & Session Plumbing | 4-6 | ⬜ Pending | — |
 | Phase 3: Visibility, the Flip & Docs | 7-10 | ⬜ Pending | — |

--- a/.vine/projects/workflow/team-layer/PROJECT-MAP.md
+++ b/.vine/projects/workflow/team-layer/PROJECT-MAP.md
@@ -8,13 +8,13 @@
 |-------|--------|---------|
 | verify | ✅ | 2026-06-18 |
 | inquire | ✅ | 2026-06-18 |
-| navigate | ⬜ | — |
+| navigate | 🚧 | 2026-06-22 |
 | evolve | ⬜ | — |
 
 ### Milestones
 
 | Phase | Slices | Status | PR |
 |-------|--------|--------|----|
-| Phase 1: Composition Model | 1-3 | ⬜ Pending | — |
+| Phase 1: Composition Model | 1-3 | 🚧 Active | — |
 | Phase 2: Discovery & Session Plumbing | 4-6 | ⬜ Pending | — |
 | Phase 3: Visibility, the Flip & Docs | 7-10 | ⬜ Pending | — |

--- a/.vine/projects/workflow/team-layer/PROJECT-MAP.md
+++ b/.vine/projects/workflow/team-layer/PROJECT-MAP.md
@@ -15,6 +15,6 @@
 
 | Phase | Slices | Status | PR |
 |-------|--------|--------|----|
-| Phase 1: Composition Model | 1-3 | ✅ Complete | — |
+| Phase 1: Composition Model | 1-3 | ✅ Complete | [#122](https://github.com/moduloMoments/VINE/pull/122) |
 | Phase 2: Discovery & Session Plumbing | 4-6 | ⬜ Pending | — |
 | Phase 3: Visibility, the Flip & Docs | 7-10 | ⬜ Pending | — |

--- a/.vine/projects/workflow/team-layer/PROJECT-MAP.md
+++ b/.vine/projects/workflow/team-layer/PROJECT-MAP.md
@@ -7,6 +7,14 @@
 | Phase | Status | Updated |
 |-------|--------|---------|
 | verify | ✅ | 2026-06-18 |
-| inquire | ⬜ | — |
+| inquire | ✅ | 2026-06-18 |
 | navigate | ⬜ | — |
 | evolve | ⬜ | — |
+
+### Milestones
+
+| Phase | Slices | Status | PR |
+|-------|--------|--------|----|
+| Phase 1: Composition Model | 1-3 | ⬜ Pending | — |
+| Phase 2: Discovery & Session Plumbing | 4-6 | ⬜ Pending | — |
+| Phase 3: Visibility, the Flip & Docs | 7-10 | ⬜ Pending | — |

--- a/.vine/projects/workflow/team-layer/SPEC.md
+++ b/.vine/projects/workflow/team-layer/SPEC.md
@@ -112,7 +112,7 @@ new command.
 
 ### Work Slices
 
-## Phase 1: Composition Model (Slices 1-3) ⬜
+## Phase 1: Composition Model (Slices 1-3) ✅
 Summary: Formalize the `.vine.local/` contract and teach overlay + profile loading to compose the
 personal root. No `.gitignore` flip yet — loaders learn the new location while the old one still
 works, so nothing breaks mid-cycle.

--- a/.vine/projects/workflow/team-layer/SPEC.md
+++ b/.vine/projects/workflow/team-layer/SPEC.md
@@ -161,6 +161,16 @@ Summary: Make every command find projects in both roots, relocate the session-st
 Session boundary: After this phase, all commands operate correctly across both roots while the
 `.gitignore` is still in its old state. Ships as PR 2.
 
+**Added 2026-06-22 (worktree resolution — see knowledge ADR
+`2026-06-22-anchor-the-personal-root-at-the-repo-shared-across-worktrees`):** gitignored personal
+state is invisible to git worktrees/clones (a worktree session can't see the main checkout's
+`.vine.local/`). Phase 2 must resolve the personal root from git, not cwd: the **shared** personal
+root (profile, overlays, local projects, pause) anchors at the primary worktree via
+`git rev-parse --git-common-dir`, while the **`ACTIVE`** sentinel moves to the per-worktree git dir
+(`git rev-parse --git-dir`) so hooks don't cross-fire between worktrees. Non-git dirs fall back to
+cwd-relative. This extends Slice 4 (discovery resolves the shared root) and Slice 5 (ACTIVE/PAUSE
+relocation uses the git anchors); STATE.md's `.vine.local/` contract is amended here to match.
+
 ### Slice 4: Two-root project discovery
 **Goal**: Extend the 7 prose scan sites (status, resume, pause, navigate, inquire, evolve, init's
 archive sweep) and trellis's glob to scan `.vine/projects/*/*/` **and** `.vine.local/projects/*/*/`,

--- a/.vine/projects/workflow/team-layer/SPEC.md
+++ b/.vine/projects/workflow/team-layer/SPEC.md
@@ -1,0 +1,280 @@
+# Feature Spec: Personal/Local Layer (#52, reshaped)
+## Date: 2026-06-18
+## Built on: CONTEXT.md (2026-06-18)
+## Decisions made by: Rob
+
+### Problem Statement
+
+#52 was scoped as a "team layer" — team conventions that install with the project. Inquire
+reshaped it: a *prescribed* team-overlay mechanism (named `context/teams/<name>.md` files, a
+`vine:team` command, a cross-team precedence engine) is VINE imposing a shape that orgs should
+own. Team structure varies company to company, so it's repo/team-owned, not framework-owned
+(the repo-owned-decisions principle).
+
+What *is* genuinely VINE-owned, and what this cycle ships:
+
+1. **The personal/local split.** A gitignored sibling root `.vine.local/` mirroring `.vine/`,
+   holding everything that's personal to one machine: personal overlays, the engineer profile,
+   the active-session sentinel, pause state, and local-only feature projects. This is your
+   machine vs the shared tree — no org redefines it.
+2. **The #108 gitignore inversion.** Replace the brittle deny-then-allowlist root `.gitignore`
+   with track-by-default: `.vine/` is tracked, `.vine.local/` is ignored, and that's the whole
+   rule. The knowledge record gates #108 on `.vine.local/` landing and asks for the flip in one
+   coherent move — this cycle is that move.
+3. **Per-feature visibility.** New projects default to shared; verify offers a "keep local"
+   opt-out; evolve offers local→shared promotion at wrap-up.
+4. **A documented recommendation for teams** (not a mechanism): teams configure repo-level
+   overlays (`shared.md` and the existing `<!-- class: policy -->` marker) however their org
+   maps. Distribution of those overlays is the plugin cycle's job (#57).
+
+**AC reinterpretation (intent over letter):** #52's intent — "team conventions install with the
+project" — is satisfied by the mechanism that already exists (tracked `shared.md` + policy-class
+marker) plus #57's plugin distribution. The prescribed-layer letter is dropped as
+over-engineering. #52's AC4 (conflict-safe conventions) is already realized by the append-only,
+one-record-per-file patterns; this cycle extends the tracked/local split to feature directories.
+
+### Approach
+
+**Sibling root, full inversion.** `.vine.local/` mirrors `.vine/`'s structure on demand
+(`context/`, `projects/`, optionally `knowledge/`, plus `PROFILE.md` and `ACTIVE`). The entire
+root is gitignored, so the root `.gitignore` collapses to a single line — `.vine.local/` — with
+zero per-file rules inside `.vine/`. Every personal/ephemeral file relocates out of `.vine/`:
+
+| Today (gitignored in-place)            | After                                         |
+|----------------------------------------|-----------------------------------------------|
+| `.vine/context/*.local.md`             | `.vine.local/context/<name>.md` (drop suffix) |
+| `.vine/PROFILE.md`                     | `.vine.local/PROFILE.md`                      |
+| `.vine/ACTIVE`                         | `.vine.local/ACTIVE`                          |
+| `.vine/projects/<d>/<f>/PAUSE.md`      | `.vine.local/projects/<d>/<f>/PAUSE.md`       |
+| (local-only projects: didn't exist)    | `.vine.local/projects/<d>/<f>/`               |
+
+**Personal layer = same filename, different root.** Today the repo overlay (`shared.md`) and the
+personal overlay (`shared.local.md`) are distinguished by *suffix* in one directory. After the
+move, the distinguisher is *location*: `.vine/context/shared.md` (repo) vs
+`.vine.local/context/shared.md` (personal). The loader reads both and composes personal-over-repo
+with the policy-class carve-out unchanged. The `.local` suffix is dropped because the root already
+signals personal scope. Any repo overlay (`shared.md`, phase overlays) can have a personal
+counterpart at the mirrored path.
+
+**Discovery scans two roots.** Commands that enumerate features scan both `.vine/projects/*/*/`
+and `.vine.local/projects/*/*/`, applying the same `.resolved` / `.archive/` filtering to each.
+To avoid restating the two-root rule at 7+ sites (the duplication the referential-homes record
+warns against), the rule is stated once (Filtering Convention in `references/STATE.md`) and the
+scan sites reference it.
+
+**Per-path commit test.** The commit-or-skip test stops checking the `projects/` root and instead
+runs `git check-ignore` on the *specific* feature directory. A project under `.vine/projects/`
+reads as committable; one under `.vine.local/projects/` reads as ignored — so the same test
+routes shared and local projects correctly with no special-casing.
+
+**Visibility.** verify (the only command that creates projects) defaults new projects to
+`.vine/projects/` (shared, fits work-in-public) and surfaces a one-tap "keep this local" option
+that routes to `.vine.local/projects/` instead. evolve offers local→shared promotion (move the
+directory) at wrap-up.
+
+**Team recommendation (docs only).** README's "Piloting" section becomes a solo→team graduation
+path that points at the existing primitives: edit the tracked `shared.md`, mark team governance
+`<!-- class: policy -->`, and (future) install team overlays as plugins (#57). No new files, no
+new command.
+
+### Acceptance Criteria
+
+1. Root `.gitignore` is track-by-default: `.vine/` and all current subdirs are tracked with no
+   per-file negation lines; `.vine.local/` is the only ignore rule. `git check-ignore` reports
+   every file under `.vine/` as tracked and every file under `.vine.local/` as ignored.
+2. The overlay loader composes a personal overlay read from `.vine.local/context/<name>.md` over
+   the repo overlay at `.vine/context/<name>.md`, preserving the policy-class carve-out
+   (personal cannot weaken a `<!-- class: policy -->` section). Absent personal files → no change
+   in behavior.
+3. The profile loader reads `.vine.local/PROFILE.md`; absent it, commands behave as they do with
+   no profile (no prompt, no warning).
+4. `vine:navigate` writes the active sentinel to `.vine.local/ACTIVE`; `journal-check.sh` and
+   `run-tests.sh` read that location; the active-session hook fires correctly against it.
+5. `vine:pause` writes `PAUSE.md` under the feature's path within `.vine.local/projects/...`, and
+   resume/inquire/navigate/evolve consume it from there (consumed-once rule intact).
+6. All feature-enumerating commands (status, resume, pause, navigate, inquire, evolve, init's
+   archive sweep) and trellis discover projects in **both** `.vine/projects/` and
+   `.vine.local/projects/`, with `.resolved` and `.archive/` filtering applied to each; the
+   two-root rule is stated once and referenced, not restated per site.
+7. The commit-or-skip test in verify/inquire/navigate/evolve runs against the specific feature
+   directory, committing shared projects and skipping local ones.
+8. `vine:verify` defaults new projects to shared and offers a "keep local" option that creates the
+   project under `.vine.local/projects/`; `vine:evolve` offers local→shared promotion.
+9. `vine:init` scaffolds the new single-line `.gitignore` for fresh repos, and its Upgrade Mode
+   offers existing repos an opt-in migration (relocate personal files + flip `.gitignore`) where
+   **declining changes nothing** (#58 rename-fallback).
+10. This repo is migrated as the worked example: `.gitignore` flipped, `ACTIVE` relocation wired,
+    `git status` shows no unintended tracking changes for existing committed artifacts.
+11. README "Piloting", CLAUDE.md tracked/gitignored bullets, init's `.vine/README.md` scaffold,
+    and `references/STATE.md` (Forward references, Committing Artifacts, ACTIVE guarantee,
+    Filtering Convention) reflect the now-real `.vine.local/` contract and the team recommendation.
+12. `/trellis` passes; no command file references a personal path that has moved.
+
+### Work Slices
+
+## Phase 1: Composition Model (Slices 1-3) ⬜
+Summary: Formalize the `.vine.local/` contract and teach overlay + profile loading to compose the
+personal root. No `.gitignore` flip yet — loaders learn the new location while the old one still
+works, so nothing breaks mid-cycle.
+Session boundary: After this phase, the composition model is defined and documented; a personal
+overlay placed in `.vine.local/context/` composes correctly. Ships as PR 1.
+
+### Slice 1: Formalize the `.vine.local/` contract in STATE.md
+**Goal**: Turn the `**Forward references**` backlog idea (`STATE.md:484-486`) into the real
+contract: `.vine.local/` structure (mirrors `.vine/`), what it holds, gitignored-entirely
+guarantee. Update Committing Artifacts (per-path test), the ACTIVE "never leaves the machine"
+guarantee (new location), the Filtering Convention (two-root scan, stated once), and the
+Source-of-Truth table.
+**Depends on**: Nothing.
+**Files likely touched**: `references/STATE.md`.
+**Acceptance criteria**: AC1 (contract text), AC6 (Filtering Convention single statement), AC7
+(per-path test described). Section headings keep their `<!-- required -->`/`<!-- optional -->`
+markers.
+**Complexity signal**: Medium — load-bearing contract that later slices implement against.
+
+### Slice 2: Overlay composition reads the personal root
+**Goal**: Update the Overlay Loading Protocol and Overlay Precedence in `shared.md` so the
+personal layer is read from `.vine.local/context/<name>.md` (location-based, suffix dropped) and
+composed personal-over-repo with the policy carve-out intact. Update the legacy/missing-file
+behavior accordingly. Because `init.md` embeds the `shared.md` template, update both in lockstep.
+**Depends on**: Slice 1.
+**Files likely touched**: `.vine/context/shared.md`, `commands/vine/init.md` (embedded template),
+every command's "Load Context Overlays" step if it hardcodes `.vine/context/*.local.md`.
+**Acceptance criteria**: AC2. Composition with no personal files present is a no-op.
+**Complexity signal**: Medium — touches the shared protocol referenced by all phases.
+
+### Slice 3: Profile loader path + team recommendation note
+**Goal**: Point the Engineer Profile Protocol (and any command "Load Engineer Profile" step that
+hardcodes the path) at `.vine.local/PROFILE.md`. Add the team-overlay recommendation to `shared.md`
+(repo-level overlays + policy-class marker; distribution → #57) — replacing what would have been a
+prescribed team layer with a one-paragraph pointer.
+**Depends on**: Slice 2.
+**Files likely touched**: `.vine/context/shared.md`, `commands/vine/init.md` (embedded template),
+command "Load Engineer Profile" references.
+**Acceptance criteria**: AC3, plus the team recommendation reads without dereferencing
+(Reference Legibility).
+**Complexity signal**: Low.
+
+## Phase 2: Discovery & Session Plumbing (Slices 4-6) ⬜
+Summary: Make every command find projects in both roots, relocate the session-state files
+(PAUSE/ACTIVE) and update the hook scripts that read them, and switch the commit test to per-path.
+Session boundary: After this phase, all commands operate correctly across both roots while the
+`.gitignore` is still in its old state. Ships as PR 2.
+
+### Slice 4: Two-root project discovery
+**Goal**: Extend the 7 prose scan sites (status, resume, pause, navigate, inquire, evolve, init's
+archive sweep) and trellis's glob to scan `.vine/projects/*/*/` **and** `.vine.local/projects/*/*/`,
+filtering each by `.resolved` / `.archive/`. Per the referential-homes record, reference the
+single Filtering Convention statement (Slice 1) rather than restating the two-root rule at each
+site.
+**Depends on**: Slice 1.
+**Files likely touched**: `commands/vine/{status,resume,pause,navigate,inquire,evolve,init}.md`,
+`.claude/commands/trellis.md`.
+**Acceptance criteria**: AC6.
+**Complexity signal**: Medium — many sites, but mechanical once the convention is referenced.
+
+### Slice 5: Relocate PAUSE + ACTIVE and update hook scripts
+**Goal**: pause writes `PAUSE.md` under `.vine.local/projects/<d>/<f>/`; resume and the consume
+sites (inquire/navigate/evolve) read it there. navigate writes `.vine.local/ACTIVE`
+(`navigate.md:83` template). Update `journal-check.sh:12` and `run-tests.sh:35` to the new ACTIVE
+location.
+**Depends on**: Slice 4.
+**Files likely touched**: `commands/vine/{pause,resume,navigate,inquire,evolve}.md`,
+`.vine/scripts/journal-check.sh`, `.vine/scripts/run-tests.sh`.
+**Acceptance criteria**: AC4, AC5.
+**Complexity signal**: Medium — hook scripts must move in lockstep with navigate's writer.
+
+### Slice 6: Per-path commit test
+**Goal**: Replace the `git check-ignore -q .vine/projects` root test (`verify.md:331`,
+`inquire.md:314`, and the navigate/evolve commit logic) with a check against the specific feature
+directory, so shared projects commit and local ones skip.
+**Depends on**: Slice 1.
+**Files likely touched**: `commands/vine/{verify,inquire,navigate,evolve}.md`.
+**Acceptance criteria**: AC7.
+**Complexity signal**: Low.
+
+## Phase 3: Visibility, the Flip & Docs (Slices 7-10) ⬜
+Summary: Add the user-facing shared/local choice, perform the `.gitignore` inversion and migrate
+this repo, and update all documentation. The flip lands last, after everything reads the new
+locations.
+Session boundary: Feature complete and ready for evolve. Ships as PR 3.
+
+### Slice 7: verify shared-vs-local prompt
+**Goal**: At project creation, verify defaults to shared (`.vine/projects/`) and offers a one-tap
+"keep local" option routing to `.vine.local/projects/`. Use AskUserQuestion per the Interaction
+Constraints.
+**Depends on**: Slices 1, 6.
+**Files likely touched**: `commands/vine/verify.md`.
+**Acceptance criteria**: AC8 (verify half).
+**Complexity signal**: Low.
+
+### Slice 8: evolve local→shared promotion
+**Goal**: At wrap-up, evolve detects a local project and offers to promote it to shared (move the
+directory tree from `.vine.local/projects/` to `.vine/projects/`), then commits as usual.
+**Depends on**: Slices 4, 6.
+**Files likely touched**: `commands/vine/evolve.md`.
+**Acceptance criteria**: AC8 (evolve half).
+**Complexity signal**: Low-Medium — directory move + commit interaction.
+
+### Slice 9: The `.gitignore` flip + init scaffold + Upgrade Mode + repo migration
+**Goal**: Replace the root `.gitignore` deny-allowlist with `.vine.local/` (single rule). Update
+init Step 6 (gitignore template) and Step 8 Upgrade Mode to offer existing repos an opt-in
+migration (relocate personal files, flip `.gitignore`) where declining is a no-op. Migrate THIS
+repo as the worked example (relocate ACTIVE wiring; flip `.gitignore`); verify with
+`git check-ignore` + `git status` that no committed artifact changes tracking unexpectedly.
+**Depends on**: Slices 2, 3, 4, 5, 6 (everything must read the new locations before the flip).
+**Files likely touched**: `.gitignore`, `commands/vine/init.md` (Steps 6, 8).
+**Acceptance criteria**: AC1, AC9, AC10.
+**Complexity signal**: High — the riskiest change; isolated to its own PR by design.
+
+### Slice 10: Documentation sweep
+**Goal**: README "Piloting" → solo→team graduation path + repo-level team-overlay recommendation;
+CLAUDE.md tracked/gitignored bullets; init's `.vine/README.md` scaffold table + the forward-looking
+#52 block (`init.md:349-358`) → reflect the now-real `.vine.local/`. Run the State Artifact
+Addition Checklist for the new directory convention. `/trellis` green.
+**Depends on**: Slice 9.
+**Files likely touched**: `README.md`, `CLAUDE.md`, `commands/vine/init.md`, `references/STATE.md`.
+**Acceptance criteria**: AC11, AC12.
+**Complexity signal**: Low-Medium.
+
+### Tech Debt Integration
+
+- **Brittle root `.gitignore` (deny-then-allowlist)** — **Address now** (Slice 9). The inversion
+  is the fix; resolves #108. This is the central reason #108 was gated on `.vine.local/`.
+- **README "Piloting" thin/stale** — **Address now** (Slice 10), as #52 explicitly calls for the
+  solo→team graduation path.
+- **Prose-only project discovery restated at 7+ sites** — **Address during** (Slices 1 + 4).
+  Rather than worsen the duplication by adding a second root to every site, state the two-root
+  Filtering Convention once and reference it (referential-homes record). Conscious, bounded
+  refactor folded into work already touching those sites.
+- **New debt accepted: none.** The inversion removes per-file gitignore rules rather than adding
+  any.
+
+### Backlog Updates
+
+- **#108 (track-by-default gitignore inversion)** — closed by Slice 9; the flip the record gated
+  on `.vine.local/` is performed here.
+- **#57 (plugin distribution)** — unblocked: this cycle finalizes the overlay-composition model
+  #57 builds on. The team-overlay *recommendation* (Slice 3 / Slice 10) is the explicit seam where
+  #57's plugin distribution attaches. No distribution mechanism ships here.
+- **Dropped from #52 (over-engineering):** prescribed `context/teams/<name>.md` format, a
+  `vine:team` command, and a cross-team precedence engine. Recorded as deliberately out-of-scope —
+  team structure is repo/team-owned. If a future need for VINE-level multi-team composition
+  emerges, it earns its own cycle.
+
+### Dependencies & Risks
+
+- **The `.gitignore` flip is the highest-risk change.** It alters what the live repo tracks.
+  Mitigation: it lands last (Slice 9), after every loader/discovery/session-state path reads the
+  new locations; verify with `git check-ignore` over both roots and `git status` before/after.
+- **Hook-script lockstep.** `journal-check.sh` and `run-tests.sh` hardcode `.vine/ACTIVE`. If
+  navigate's writer moves to `.vine.local/ACTIVE` without updating them, the active-session hook
+  breaks mid-session. Slice 5 moves writer and readers together.
+- **Backward-compat (#58 pattern).** Existing solo repos may hold `.vine/context/shared.local.md`
+  and `.vine/PROFILE.md`. Upgrade Mode must relocate them on opt-in; declining must change nothing.
+  (This repo currently has neither file, lowering migration risk for the worked example.)
+- **create-vine packaging.** The npm package ships init + commands but not the contributor scripts.
+  The `.gitignore` template change ships; confirm `create-vine` scaffolds the new single-line
+  ignore for fresh installs.
+- **#57 boundary.** This cycle must finalize the composition model without pre-empting #57's
+  distribution design — ship the mechanism and the recommendation, not propagation.

--- a/commands/vine/evolve.md
+++ b/commands/vine/evolve.md
@@ -525,7 +525,7 @@ session-start consumption normally removed it already, so a PAUSE.md surviving t
 then delete the file. Never delete it silently — the same surface-then-delete rule the other
 consumption triggers follow (PAUSE.md lifecycle in `references/STATE.md`).
 
-**Offer to archive (#56 — move resolved work out of the way).** Only when the engineer just resolved
+**Offer to archive — move resolved work out of the way.** Only when the engineer just resolved
 the project, offer to archive it — move it to `.vine/projects/.archive/<domain>/<feature-slug>/`, which
 preserves the artifacts but gets completed work fully out of the way (lifecycle in `references/STATE.md`,
 "Project Lifecycle"). An active project is never archived. Use `AskUserQuestion`:

--- a/commands/vine/evolve.md
+++ b/commands/vine/evolve.md
@@ -303,7 +303,7 @@ say so and move on — not every feature is a learning experience.
 
 ### Update Engineer Profile
 
-Based on the completed cycle, propose updates to `.vine/PROFILE.md`. This is the concrete,
+Based on the completed cycle, propose updates to `.vine.local/PROFILE.md`. This is the concrete,
 persistent output of user evolution — the profile grows with each VINE cycle.
 
 **Domain expertise update:**
@@ -315,7 +315,7 @@ Check the current feature's domain against the profile:
   areas that suggest the level was too high? Propose an update only if the level should change.
 - **If the domain doesn't exist**: Propose adding it with a level based on what you observed
   during the cycle.
-- **If no profile exists yet**: Offer to create `.vine/PROFILE.md` with an initial entry for
+- **If no profile exists yet**: Offer to create `.vine.local/PROFILE.md` with an initial entry for
   this domain.
 
 Use `AskUserQuestion` to present the proposed change:
@@ -346,7 +346,7 @@ only when the engineer genuinely wants to record something. If they choose the d
 write bullet points focused on the engineer's contributions and decisions — not what they
 "learned." Present the draft for editing before writing to the file.
 
-For each accepted change, write the update to `.vine/PROFILE.md` directly. Create the file
+For each accepted change, write the update to `.vine.local/PROFILE.md` directly. Create the file
 if needed, using the format documented in `references/STATE.md`.
 
 ### Suggest Claude Memory Updates
@@ -383,7 +383,7 @@ Route each candidate learning to exactly one home, first match wins:
 
 1. Regenerable from the code? (structure, where-is-X) → home it nowhere; it regenerates on demand.
 2. Non-regenerable judgment or gotcha tied to a domain? → `.vine/knowledge/<domain>/` (**this step**).
-3. Per-engineer depth or expertise? → `.vine/PROFILE.md` (handled in *Update Engineer Profile*).
+3. Per-engineer depth or expertise? → `.vine.local/PROFILE.md` (handled in *Update Engineer Profile*).
 4. Cross-phase VINE protocol / inter-phase routing? → `.vine/context/shared.md` (*Context Overlay Update*).
 5. Repo fact every session needs, VINE or not? → `CLAUDE.md` (*CLAUDE.md Suggestions*).
 
@@ -499,7 +499,7 @@ Update PROJECT-MAP.md (if it exists) — set the evolve row to ✅ with today's 
    - Product: [brief summary of quality state]
    - Agent: [brief summary of capability growth]
    - User: [brief summary of knowledge growth]
-   - Profile: [updated/created/unchanged] (.vine/PROFILE.md)
+   - Profile: [updated/created/unchanged] (.vine.local/PROFILE.md)
 
    "Grow features on solid roots."
 ---
@@ -559,7 +559,7 @@ under *Committing Artifacts*):
 - **EVOLUTION.md** and the **`.resolved`** marker (if resolved) — VINE artifacts; stage them
   **only when the repo tracks `.vine/` artifacts**. When artifacts are untracked (gitignored, or
   a personal scope) they update on disk but stay out of the commit.
-- **`.vine/PROFILE.md`** updates (if accepted) — commonly gitignored (it's personal); stage only
+- **`.vine.local/PROFILE.md`** updates (if accepted) — commonly gitignored (it's personal); stage only
   if the repo tracks it.
 
 Never force-add a gitignored artifact. If the project was just archived, its artifacts now live

--- a/commands/vine/init.md
+++ b/commands/vine/init.md
@@ -94,9 +94,12 @@ Overlay Loading Protocol" pulls in.
   of the command; overlay instructions take precedence over command defaults when they conflict.
   (Precedence *between* the overlay layers — shared vs. personal vs. policy — is governed by
   **Overlay Precedence** below, the source of truth; this line does not override it.)
-- **Personal layer.** After reading `shared.md` and the phase overlay, read
-  `.vine/context/shared.local.md` if present and compose it per the **Personal layer** rule in
-  Overlay Precedence. Absent it, nothing changes.
+- **Personal layer.** After reading each repo overlay from `.vine/context/` (`shared.md` and the
+  phase overlay), read its personal counterpart at the mirrored path under the personal root —
+  `.vine.local/context/<name>.md` (e.g. `.vine.local/context/shared.md`,
+  `.vine.local/context/<phase>.md`) — and compose it per the **Personal layer** rule in Overlay
+  Precedence. The personal overlay is distinguished by its root, not a filename suffix (the `.local`
+  suffix is dropped). Absent any personal file, nothing changes.
 - **Legacy fallback (supported through 0.4.x).** If `.vine/context/` doesn't exist but legacy
   `.vine/hooks/` does, read the same files from `.vine/hooks/` instead and nudge once per
   session: "Heads up: this project uses the legacy `.vine/hooks/` directory — run `/vine:init`
@@ -111,22 +114,22 @@ file (and thus this protocol) is absent: the bootstrap's own read carries the mi
 ## Overlay Precedence
 
 VINE composes context from command defaults, this shared overlay (`shared.md`), and the
-engineer's personal layer (`shared.local.md`). They resolve as **flat personal-wins with
+engineer's personal layer (`.vine.local/context/`). They resolve as **flat personal-wins with
 policy carve-outs**, mirroring how Claude's own settings resolve — local overrides project,
 except an immutable enterprise-policy ceiling:
 
-- **Preference content** (every unmarked section) is personal-overridable: where `shared.local.md`
-  and `shared.md` conflict, the personal layer wins.
+- **Preference content** (every unmarked section) is personal-overridable: where a personal overlay
+  and its repo counterpart conflict, the personal layer wins.
 - **Policy content** is immutable from the personal layer. A section marked `<!-- class: policy -->`
-  directly under its heading always wins over personal overrides — `shared.local.md` cannot weaken
+  directly under its heading always wins over personal overrides — a personal overlay cannot weaken
   or replace it. Policy sections carry team governance the repo enforces regardless of personal
   preference (CI/CD gates, the team operating model).
 
-**Personal layer (`shared.local.md`).** Each command's *Load Context Overlays* step, after
-reading `shared.md` and the phase overlay, reads `.vine/context/shared.local.md` if present and
-composes it by the rule above — it overrides preference content and is ignored where it would
-override a policy-class section. The file is gitignored (personal scope); absent it, nothing
-changes.
+**Personal layer (`.vine.local/context/`).** Each command's *Load Context Overlays* step, after
+reading a repo overlay (`shared.md`, a phase overlay), reads its personal counterpart at the
+mirrored path `.vine.local/context/<name>.md` if present and composes it by the rule above — it
+overrides preference content and is ignored where it would override a policy-class section. Personal
+overlays live under the gitignored personal root (`.vine.local/`); absent them, nothing changes.
 
 Only policy-class sections carry the marker; unmarked means preference.
 

--- a/commands/vine/init.md
+++ b/commands/vine/init.md
@@ -133,6 +133,18 @@ overlays live under the gitignored personal root (`.vine.local/`); absent them, 
 
 Only policy-class sections carry the marker; unmarked means preference.
 
+### Team conventions (recommendation)
+
+Team conventions are **repo-owned, not framework-prescribed** — team structure varies org to org, so
+VINE ships the mechanism, not a fixed shape. To make conventions travel with the project, put them in
+the tracked repo overlay (`.vine/context/shared.md`) and mark anything the team enforces regardless of
+personal preference with `<!-- class: policy -->` (per Overlay Precedence above, the personal
+`.vine.local/` layer cannot weaken a policy section). That pair — tracked `shared.md` plus the policy
+marker — is the whole team layer; no separate team-overlay file or `vine:team` command is needed.
+Distributing those overlays across repos, so an engineer installs the team conventions they belong to,
+is the job of plugin distribution in a later cycle ([#57](https://github.com/moduloMoments/VINE/issues/57):
+overlay distribution as plugins).
+
 ## Project Directory Convention
 
 All VINE project artifacts MUST be created under `.vine/projects/<domain>/<feature-slug>/`.
@@ -166,7 +178,7 @@ Internal, not shown to the engineer. Apply this stance in all VINE phases:
 
 ## Engineer Profile Protocol
 
-After loading overlays, check for `.vine/PROFILE.md`. If it exists, read the Domain Expertise
+After loading overlays, check for `.vine.local/PROFILE.md`. If it exists, read the Domain Expertise
 table. Match the feature's domain against the profile's entries.
 
 - **If the domain is in the profile**: Note their level for this session. Use it to calibrate
@@ -405,7 +417,7 @@ After generating overlays, briefly mention the engineer profile to the engineer:
 Do **not** ask any domain rating questions here. The profile seeds itself through vine:verify
 as the engineer works in different domains. This step is purely informational.
 
-If `.vine/PROFILE.md` already exists (e.g., from a previous init or manual creation), skip
+If `.vine.local/PROFILE.md` already exists (e.g., from a previous init or manual creation), skip
 this message entirely.
 
 ## Step 8: Upgrade Existing Projects
@@ -640,7 +652,7 @@ list them and offer to archive them, mirroring evolve's archive mechanics (lifec
 📋 Next step: Run `/vine:verify` to start your first feature.
    Your context overlays will be loaded automatically.
 
-👤 Your engineer profile (.vine/PROFILE.md) will build as you work —
+👤 Your engineer profile (.vine.local/PROFILE.md) will build as you work —
    each new domain prompts a quick familiarity check during verify.
 
 💡 Tip: As you complete VINE cycles, `/vine:evolve` will suggest

--- a/commands/vine/init.md
+++ b/commands/vine/init.md
@@ -140,10 +140,9 @@ VINE ships the mechanism, not a fixed shape. To make conventions travel with the
 the tracked repo overlay (`.vine/context/shared.md`) and mark anything the team enforces regardless of
 personal preference with `<!-- class: policy -->` (per Overlay Precedence above, the personal
 `.vine.local/` layer cannot weaken a policy section). That pair — tracked `shared.md` plus the policy
-marker — is the whole team layer; no separate team-overlay file or `vine:team` command is needed.
-Distributing those overlays across repos, so an engineer installs the team conventions they belong to,
-is the job of plugin distribution in a later cycle ([#57](https://github.com/moduloMoments/VINE/issues/57):
-overlay distribution as plugins).
+marker — is the whole team layer; no separate team-overlay file or dedicated command is needed. To
+share those overlays across repos today, commit the overlay files your team needs; packaged
+cross-repo distribution is a separate, future concern.
 
 ## Project Directory Convention
 
@@ -358,19 +357,14 @@ and config. Full schema: `references/STATE.md`.
   folds in newly discovered tooling without clobbering your edits.
 - **Add per-phase guidance.** Create or extend `context/<phase>.md` to give one phase context the
   others don't need.
-- **Keep personal tweaks local.** Drop preferences you don't want to commit into
-  `context/shared.local.md` — it overrides preference sections but never policy ones.
+- **Keep personal tweaks local.** Drop preferences you don't want to commit into the personal
+  overlay at `.vine.local/context/shared.md` — it overrides preference sections but never policy ones.
 
-### Plugins & team distribution (forward-looking)
+### Team distribution
 
-Packaging VINE as a Claude Code plugin and distributing shared team overlays are on the roadmap,
-not yet shipped. Track progress here:
-
-- [VINE #57 — Claude Code plugin: packaging + team-overlay distribution](https://github.com/moduloMoments/VINE/issues/57)
-- [VINE #52 — Team layer](https://github.com/moduloMoments/VINE/issues/52)
-
-Until those land, share overlays the manual way: commit the files under `.vine/context/` you want
-your team to share, and keep personal-only tweaks in the gitignored `.local` layer.
+To share overlays with your team, commit the files under `.vine/context/` you want shared, and mark
+team-enforced sections `<!-- class: policy -->` so a personal overlay can't weaken them. Keep
+personal-only tweaks in the gitignored personal root (`.vine.local/context/`).
 ````
 
 ## Step 5: Create Projects Directory

--- a/commands/vine/status.md
+++ b/commands/vine/status.md
@@ -22,7 +22,7 @@ gracefully: read the phase overlay if present, otherwise proceed on command defa
 
 ## Load Engineer Profile
 
-After loading overlays, check for the engineer's profile at `.vine/PROFILE.md`.
+After loading overlays, check for the engineer's profile at `.vine.local/PROFILE.md`.
 
 If it exists, note it for the status display. No depth hint needed — status is a read-only
 display command.

--- a/commands/vine/verify.md
+++ b/commands/vine/verify.md
@@ -42,7 +42,7 @@ that seeds new domains:
   3. "Learning" — "I've seen it but haven't worked in it much"
   4. "New" — "This is my first time in this area"
 
-  Add the domain to `.vine/PROFILE.md` with the selected level and today's date. If
+  Add the domain to `.vine.local/PROFILE.md` with the selected level and today's date. If
   PROFILE.md doesn't exist yet, create it with the format documented in `references/STATE.md`.
 
 If no profile exists and the engineer hasn't confirmed a domain yet, do nothing — the prompt

--- a/references/STATE.md
+++ b/references/STATE.md
@@ -4,11 +4,18 @@ This document defines the state artifacts that flow between VINE phases. Each ph
 
 ## Directory Structure
 
-Per-feature artifacts live under `.vine/projects/<domain>/<feature-slug>/` in the project root. The domain is the logical area the feature touches (e.g., `payments`, `auth`, `onboarding`). The feature slug is a short, lowercase, hyphenated name for the specific work (e.g., `webhook-support`, `retry-logic`). Both are confirmed with the engineer during vine:verify via structured select prompts.
+Per-feature artifacts live under `<root>/projects/<domain>/<feature-slug>/` in the project root — the shared root `.vine/` by default, or the personal root `.vine.local/` for local-only work (see *The two roots* below). The domain is the logical area the feature touches (e.g., `payments`, `auth`, `onboarding`). The feature slug is a short, lowercase, hyphenated name for the specific work (e.g., `webhook-support`, `retry-logic`). Both are confirmed with the engineer during vine:verify via structured select prompts.
 
 This namespacing allows multiple features to be VINEd concurrently without collision — even features in the same domain. It also provides discoverability: `ls .vine/projects/payments/` shows all payment-related VINE work at a glance.
 
-Per-repo artifacts (like `.vine/PROFILE.md`) live directly under `.vine/` and persist across all VINE cycles.
+### The two roots: `.vine/` (shared) and `.vine.local/` (personal)
+
+VINE state lives under two sibling roots in the project root:
+
+- **`.vine/`** — the **shared** tree, tracked by default, travels with the repo: team overlays (`.vine/context/`), shared feature projects (`.vine/projects/`), durable knowledge (`.vine/knowledge/`), and `.vine/README.md`.
+- **`.vine.local/`** — the **personal** tree: a gitignored sibling root that mirrors `.vine/`'s structure on demand (`context/`, `projects/`, optionally `knowledge/`, plus `PROFILE.md` and `ACTIVE`). It holds everything personal to one machine — personal overlays, the engineer profile (`.vine.local/PROFILE.md`), the active-session sentinel (`.vine.local/ACTIVE`), pause state (`.vine.local/projects/<domain>/<feature-slug>/PAUSE.md`), and local-only feature projects. The **whole root is gitignored** — a single `.vine.local/` rule, with no per-file ignore rules inside `.vine/`.
+
+The shared/personal split is **location-based**: a file's root marks its scope, not a filename suffix. A repo overlay at `.vine/context/shared.md` has a personal counterpart at `.vine.local/context/shared.md` (the `.local` filename suffix is dropped — the root already signals personal scope). The overlay loader composes personal-over-repo with the policy-class carve-out unchanged (see `.vine/context/shared.md`, "Overlay Precedence"). Per-repo personal state persists across all VINE cycles.
 
 ## State Files
 
@@ -234,11 +241,11 @@ thinking, what to pick up first, anything that won't survive a session break]
 
 **Lifecycle:**
 
-1. **Created** by `vine:pause` — detects current phase from artifact presence, asks the engineer for notes, writes PAUSE.md to the feature directory.
+1. **Created** by `vine:pause` — detects current phase from artifact presence, asks the engineer for notes, writes PAUSE.md under the feature's mirrored path in `.vine.local/projects/<domain>/<feature-slug>/` (the personal root, so pause state stays local even for a shared `.vine/projects/` feature).
 2. **Overwritten** by subsequent `vine:pause` calls — only one pause state exists per feature at a time.
 3. **Consumed** (read, surfaced, then deleted) by whatever picks the work back up. Every deletion trigger:
    - `vine:resume` — after displaying the notes.
-   - `vine:navigate` — at session start, the same moment `.vine/ACTIVE` is written; notes are surfaced in the starting-point summary first.
+   - `vine:navigate` — at session start, the same moment `.vine.local/ACTIVE` is written; notes are surfaced in the starting-point summary first.
    - `vine:inquire` — at session start, after reading CONTEXT.md (handles a pause taken after verify); notes are surfaced in the context summary first.
    - `vine:evolve` — at session start, after reading the feature's artifacts; notes are surfaced first.
    - `vine:evolve` when writing `.resolved` — backstop; session-start consumption normally removed PAUSE.md already, so a surviving one is surfaced then deleted like the rest (its notes appeared after evolve began and aren't necessarily stale).
@@ -252,9 +259,9 @@ thinking, what to pick up first, anything that won't survive a session break]
 - **One per feature.** No history of pause states. The most recent pause is the only one that matters.
 - **Consumed-once.** Picking the work back up deletes the file. Notes worth keeping beyond the resume belong in NAVIGATION.md's Remaining Work, not in PAUSE.md.
 
-### .vine/ACTIVE (active-session sentinel, written by vine:navigate)
+### .vine.local/ACTIVE (active-session sentinel, written by vine:navigate)
 
-An ephemeral repo-level sentinel marking "a navigate session is active on this feature right now." It lives at `.vine/ACTIVE` (repo root, not under a feature directory), is covered by the standard `.vine/*` gitignore, and never leaves the machine — so pulled In-Progress journals from teammates can never make installed hooks fire.
+An ephemeral repo-level sentinel marking "a navigate session is active on this feature right now." It lives at `.vine.local/ACTIVE` (repo root, under the gitignored personal tree, not inside a feature directory) and never leaves the machine — so pulled In-Progress journals from teammates can never make installed hooks fire.
 
 ```
 feature: .vine/projects/<domain>/<feature-slug>
@@ -268,7 +275,7 @@ Its consumers are native hook scripts (see `.vine/scripts/`): they test the sent
 
 1. **Written** by `vine:navigate` at session start, the same moment any PAUSE.md is consumed. At a phase group boundary where the engineer continues immediately, navigate updates the `phase:` line instead of rewriting.
 2. **Deleted** at every session end: navigate's completion and pause-between-slices paths, `vine:pause`, and `vine:evolve` at session start (an evolve session means no navigate session is active).
-3. **Stale sentinel escape hatch:** if a session dies without cleanup (crash, closed terminal), hooks may fire against inactive work. The fix is `rm .vine/ACTIVE` — hook block messages name this command.
+3. **Stale sentinel escape hatch:** if a session dies without cleanup (crash, closed terminal), hooks may fire against inactive work. The fix is `rm .vine.local/ACTIVE` — hook block messages name this command.
 
 **Design constraints:**
 
@@ -278,11 +285,11 @@ Its consumers are native hook scripts (see `.vine/scripts/`): they test the sent
 
 ### .vine/scripts/ (native hook scripts)
 
-Shell-script home for VINE's native hook scripts — the enforcement layer behind guarantees that command prose can only request. Scripts are wired into a repo's hook configuration by init's scaffold offer (declinable; declining changes nothing on disk). All scripts are POSIX sh, treat `.vine/ACTIVE`'s feature path as an opaque repo-relative string, and **fail open**: no sentinel, missing tooling, or ambiguity exits 0 — enforcement degrades, sessions never break.
+Shell-script home for VINE's native hook scripts — the enforcement layer behind guarantees that command prose can only request. Scripts are wired into a repo's hook configuration by init's scaffold offer (declinable; declining changes nothing on disk). All scripts are POSIX sh, treat `.vine.local/ACTIVE`'s feature path as an opaque repo-relative string, and **fail open**: no sentinel, missing tooling, or ambiguity exits 0 — enforcement degrades, sessions never break.
 
 | Script | Hook event | Behavior |
 |--------|------------|----------|
-| `journal-check.sh` | PreToolUse (Bash) | Blocks `git commit` (exit 2) while a navigate session is active and the active feature's NAVIGATION.md is older than the last commit. The block message names the journal and the `rm .vine/ACTIVE` escape hatch. |
+| `journal-check.sh` | PreToolUse (Bash) | Blocks `git commit` (exit 2) while a navigate session is active and the active feature's NAVIGATION.md is older than the last commit. The block message names the journal and the `rm .vine.local/ACTIVE` escape hatch. |
 
 Validation/lint enforcement is deliberately outside the scaffold: when and how to run a project's checks depends on its tooling, so that decision stays with the repo (native hooks in `.claude/settings.json` are available directly). VINE's validation contract is the optional fenced `## Validation` block in `.vine/context/shared.md` (keys `lint`/`typecheck`/`test`/`test-all`/`build`/`extra`, all optional); `vine-verification` reads it and falls back to prose inference when it is absent.
 
@@ -344,7 +351,7 @@ The universal progress tracker. Shows at-a-glance where a feature stands in the 
 
 The engineer profile. Tracks per-domain expertise within this specific repo so VINE commands can adjust explanation depth — more narration in unfamiliar areas, more concise in comfort zones.
 
-Unlike per-feature artifacts, PROFILE.md lives at `.vine/PROFILE.md` (repo root, not under a feature directory). It persists across all VINE cycles and grows over time.
+Unlike per-feature artifacts, PROFILE.md lives at `.vine.local/PROFILE.md` (under the gitignored personal root, not under a feature directory). It persists across all VINE cycles and grows over time.
 
 ```markdown
 # Engineer Profile
@@ -471,7 +478,7 @@ shared.md's identity in one line: cross-phase protocols + project-development co
 
 1. **Regenerable from the code?** (structure, call graph, where-is-X) → home it nowhere; it regenerates on demand via agentic search (see "Source of Truth vs Derived Views").
 2. **Non-regenerable judgment or gotcha tied to one domain?** (why this approach over the alternatives; "module Y is mid-migration, don't touch it") → `.vine/knowledge/<domain>/`.
-3. **Per-engineer depth, expertise, or preference?** → `.vine/PROFILE.md`.
+3. **Per-engineer depth, expertise, or preference?** → `.vine.local/PROFILE.md`.
 4. **Cross-phase VINE protocol or inter-phase routing?** → `.vine/context/shared.md` (or `.vine/context/<phase>.md` when it's one phase's mapping).
 5. **A repo fact every session needs, VINE or not?** → `CLAUDE.md`.
 
@@ -480,10 +487,6 @@ The order is narrowest-qualifying-reader-scope first, so a domain-scoped judgmen
 When a fact moves homes, leave a one-line pointer at the old location.
 
 Other surfaces reference a domain's records with a one-line pointer (`See .vine/knowledge/<domain>/`), never by inlining them.
-
-**Forward references** (conventions defined now, implemented in later cycles):
-
-- `.vine.local/` (backlog idea) — the sharing boundary for projects: tracked `.vine/projects/` is team-shared; personal work lives outside the shared tree in a gitignored sibling root mirroring `.vine/`'s structure.
 
 ## Source of Truth vs Derived Views
 
@@ -495,7 +498,7 @@ Project *state* follows the same single-home discipline the Knowledge Boundary r
 |-------|-----------------|-----------|
 | The plan — what slices and phase groups exist | `SPEC.md` | durable |
 | Implementation progress — which slices are done, with commits, decisions, learnings | `NAVIGATION.md` | durable |
-| What's active right now | `.vine/ACTIVE` | ephemeral |
+| What's active right now | `.vine.local/ACTIVE` | ephemeral |
 | Handoff notes across a session gap | `PAUSE.md` | ephemeral |
 
 **Derived views** (never authoritative; rebuilt from the sources above):
@@ -507,10 +510,12 @@ Project *state* follows the same single-home discipline the Knowledge Boundary r
 
 ## Committing Artifacts
 
-Whether VINE artifacts (`CONTEXT.md`, `SPEC.md`, `NAVIGATION.md`, `EVOLUTION.md`, `PROJECT-MAP.md`) are committed is the repo's choice, drawn by `.gitignore`:
+Whether a feature's VINE artifacts (`CONTEXT.md`, `SPEC.md`, `NAVIGATION.md`, `EVOLUTION.md`, `PROJECT-MAP.md`) are committed is determined **per feature directory**, by which root the project lives in:
 
-- **Tracked** (`.vine/projects/` not gitignored) = the team-shared choice (see the Knowledge Boundary rule). The artifacts travel with the code through history and PRs.
-- **Untracked / personal scope** (gitignored, or a future `.vine.local/` root) = artifacts stay local to the engineer. Fully supported.
+- **Shared** (`.vine/projects/<domain>/<feature-slug>/`, tracked) = the team-shared choice (see the Knowledge Boundary rule). The artifacts travel with the code through history and PRs.
+- **Local** (`.vine.local/projects/<domain>/<feature-slug>/`, under the gitignored personal root) = artifacts stay local to the engineer. Fully supported.
+
+The **commit-or-skip test** runs `git check-ignore` against the **specific feature directory**, not the `.vine/projects/` root: a path under `.vine/projects/` reads as committable, one under `.vine.local/projects/` reads as ignored — so the same test routes shared and local projects correctly with no special-casing. `vine:verify`, `vine:inquire`, `vine:navigate`, and `vine:evolve` apply it per-path before committing artifacts.
 
 The journal-before-commit guarantee holds either way: `journal-check.sh` compares NAVIGATION.md's *modification time*, not commit contents (chosen precisely because the artifacts are gitignored in most repos). Tracking changes only *what each commit carries*, never the mechanics.
 
@@ -525,7 +530,7 @@ The journal-before-commit guarantee holds either way: `journal-check.sh` compare
 | **Evolve commit** (`vine:evolve`) | — | EVOLUTION.md and the `.resolved` marker |
 | **PR** (= one phase group) | the group's commits | the group's full artifact state — SPEC (plan), NAVIGATION (record), PROJECT-MAP (tracker) — so a reviewer sees plan-vs-result beside the diff |
 
-`CLAUDE.md` and `.vine/context/` overlays are ordinary tracked repo files — commit them whenever they change, regardless of the artifact-tracking choice. `PROFILE.md` is commonly gitignored (it's personal); commit it only if the repo tracks it.
+`CLAUDE.md` and the repo overlays under `.vine/context/` are ordinary tracked repo files — commit them whenever they change, regardless of the artifact-tracking choice. `PROFILE.md` and any personal overlay live under the gitignored personal root (`.vine.local/PROFILE.md`, `.vine.local/context/`) and are never committed.
 
 **When the repo does not track artifacts**, commits carry code only; the artifacts still update on disk (for the mtime guarantee and the engineer's own continuity) but never enter a commit. No command should force-add a gitignored artifact.
 
@@ -583,13 +588,20 @@ This gets completed work fully out of the way while preserving artifacts. Archiv
 
 ### Filtering Convention
 
-Commands that present feature directory lists via `AskUserQuestion` must:
+Commands that enumerate feature directories — status, resume, pause, navigate, inquire, evolve,
+init's archive sweep, and trellis's glob — **scan both roots** and apply the same filters to each:
 
-1. Skip directories containing a `.resolved` file
-2. Skip anything under `.vine/projects/.archive/`
-3. If all projects are resolved/archived, tell the engineer and suggest starting a new cycle with `/vine:verify` — present the command in its own fenced code block so it's copy-pastable
+1. Scan **both** `.vine/projects/*/*/` (shared) **and** `.vine.local/projects/*/*/` (local-only) — a
+   feature can live in either root, so every enumeration covers the pair.
+2. Skip directories containing a `.resolved` file.
+3. Skip anything under a `.archive/` subtree in either root (`.vine/projects/.archive/`,
+   `.vine.local/projects/.archive/`).
+4. If all projects across both roots are resolved/archived, tell the engineer and suggest starting a
+   new cycle with `/vine:verify` — present the command in its own fenced code block so it's copy-pastable.
 
-If the engineer needs to access a resolved project, they can pass its path explicitly as an argument.
+This two-root scan is stated **once, here**; the scan sites reference this convention rather than
+restating the rule per site (the referential-homes anti-duplication stance). If the engineer needs to
+access a resolved project, they can pass its path explicitly as an argument.
 
 ## Chaining Protocol
 


### PR DESCRIPTION
## What

Phase 1 of 3 for the personal/local layer (#52). Defines the `.vine.local/` personal root as a real contract and teaches the overlay + profile loaders to read from it — **without** touching `.gitignore` or relocating session-state yet, so nothing breaks mid-cycle.

- **STATE.md**: `.vine.local/` is now a real contract — the two-root model (shared `.vine/` vs personal `.vine.local/`), the per-path `git check-ignore` commit test, and the two-root discovery scan stated once.
- **Overlay loader** (`shared.md` + init's embedded template): the personal layer reads from `.vine.local/context/<name>.md` (mirrored path, `.local` suffix dropped), policy-class carve-out intact.
- **Profile loader**: reads `.vine.local/PROFILE.md` across every read/write site.
- **Team recommendation**: one paragraph — team conventions are repo-owned (tracked `shared.md` + the policy marker); distribution is #57.
- **Knowledge ADR**: captures a Phase 2 decision — resolve the personal root from git so worktrees/clones share it (gitignored state is otherwise invisible to worktrees).

## Why

#52 ships the personal/local split: your machine's state (profile, overlays, sentinel, pause, local-only projects) vs the shared tree. This is PR 1 of 3 (one per phase).

Refs #52

> **Reviewer note:** STATE.md documents the `.vine.local/` end-state (ACTIVE/PAUSE/PROFILE/gitignore) *ahead* of the command + hook machinery, which relocates in Phases 2–3. That's intentional "contract leads implementation" phasing — the loaders read the new locations now while the old paths keep working until the later phases move them.

## How to test

1. Skim `references/STATE.md` → "The two roots", "Committing Artifacts", "Filtering Convention" — the `.vine.local/` contract reads coherently.
2. `sh .vine/scripts/trellis-check.sh` → 11/11 commands pass, anchors resolve.
3. With no `.vine.local/` present, overlay + profile loading is a no-op (commands behave exactly as today).

## Checklist

- [x] Tested in a VINE cycle (produced by `/vine:navigate`; trellis green, ACs verified)
- [x] Changes focused on a single concern (Phase 1 composition model)
- [x] New behavior documented (STATE.md contract, `shared.md`, init template)