### PR TITLE
team-layer Phase 2 (#52): two-root discovery + session plumbing

### DIFF
--- a/.claude/commands/trellis.md
+++ b/.claude/commands/trellis.md
@@ -255,15 +255,15 @@ markers found at all), print a warning and skip Steps 6–7.
 
 ### 5b: Discover Artifacts
 
-Use Glob to find all artifacts in `.vine/projects/`:
+Use Glob to find all artifacts per the Filtering Convention in `references/STATE.md` (both roots):
 
-- Look for `CONTEXT.md`, `SPEC.md`, `NAVIGATION.md`, `EVOLUTION.md` under
-  `.vine/projects/*/*/` (domain/feature-slug directories)
-- Look for `PROFILE.md` at `.vine/PROFILE.md`
+- Look for `CONTEXT.md`, `SPEC.md`, `NAVIGATION.md`, `EVOLUTION.md` under `.vine/projects/*/*/`
+  **and** `.vine.local/projects/*/*/` (domain/feature-slug directories)
+- Look for `PROFILE.md` at `.vine.local/PROFILE.md`
 - **Filter out**: any path containing `.archive/` and any directory containing a `.resolved` file
 - For each discovered artifact, record its path and artifact type
 
-If no `.vine/projects/` directory exists or no artifacts are found, record this — Step 7 will
+If neither root has a `projects/` directory or no artifacts are found, record this — Step 7 will
 handle the "no artifacts" case cleanly.
 
 ## Step 6: Validate Artifacts
@@ -403,13 +403,13 @@ Command validation results above are unaffected.
 
 ### Case 2: No Artifacts Found
 
-If Step 5 ran but no artifacts were discovered in `.vine/projects/` and no `.vine/PROFILE.md`
+If Step 5 ran but no artifacts were discovered in either projects root and no `.vine.local/PROFILE.md`
 exists, print:
 
 ```
 ## Artifact Validation
 
-No artifacts found in .vine/projects/ or .vine/PROFILE.md — nothing to validate.
+No artifacts found in .vine/projects/, .vine.local/projects/, or .vine.local/PROFILE.md — nothing to validate.
 This is expected if no VINE cycles have been run in this repo.
 ```
 
@@ -422,7 +422,7 @@ Print a results table with artifacts as rows and checks as columns:
 
 | Artifact                              | Sections | Table | Slice Fields | Nav Fields |
 |---------------------------------------|----------|-------|--------------|------------|
-| .vine/PROFILE.md                      | ✅       | ✅    | —            | —          |
+| .vine.local/PROFILE.md                | ✅       | ✅    | —            | —          |
 | .vine/projects/auth/login/CONTEXT.md  | ✅       | —     | —            | —          |
 | .vine/projects/auth/login/SPEC.md     | ✅       | —     | ✅           | —          |
 | .vine/projects/auth/login/NAV...md    | ✅       | —     | —            | ✅         |

--- a/.vine/knowledge/workflow/2026-06-22-anchor-the-personal-root-at-the-repo-shared-across-worktrees.md
+++ b/.vine/knowledge/workflow/2026-06-22-anchor-the-personal-root-at-the-repo-shared-across-worktrees.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Accepted — 2026-06-22
+Accepted — 2026-06-22 (amended 2026-06-22 during Slice 5 implementation — see *Amendment* below;
+`ACTIVE` stays at `.vine/ACTIVE` gitignored rather than moving to the private git dir, the shared-root
+anchoring is unchanged)
 Source: workflow/team-layer · Actor: Rob + Claude
 Supersedes: none
 
@@ -45,17 +47,21 @@ Resolve the personal root from git, not from the working directory, and split it
   worktree root). Profile, personal overlays, local-only projects, and pause state live there once
   and are seen identically from every worktree. It remains a visible sibling root at the main
   checkout.
-- **`ACTIVE` sentinel** — move it *out* of `.vine.local/` into the per-worktree private git dir
-  (`git rev-parse --git-dir` → `.git` in the main tree, `.git/worktrees/<id>/` in a linked worktree).
-  Per-tree, inherently un-committed, and the hooks resolve it the same way, so scoping stays correct.
+- **`ACTIVE` sentinel** — keep it at `.vine/ACTIVE` (gitignored), **not** in `.vine.local/`.
+  *(Amended — the original decision moved it into the per-worktree private git dir via
+  `git rev-parse --git-dir`; see Amendment below for why `.vine/ACTIVE` is simpler and equally
+  correct.)* Because `.vine/` is a tracked tree, every worktree checks out its own working copy, so a
+  gitignored `.vine/ACTIVE` written in one worktree exists only in that worktree's filesystem — it is
+  per-tree by construction, with no `git rev-parse` resolution. The gitignore inversion keeps it
+  ignored with an explicit `.vine/ACTIVE` rule alongside `.vine.local/`.
 
 Commands and hook scripts resolve these anchors rather than assuming a cwd-relative `./.vine.local/`.
 A non-git directory (no `git` available) falls back to the cwd-relative root — the single-checkout
 case is unaffected.
 
-This is folded into **Phase 2 (Discovery & Session Plumbing)** of #52, which already relocates
-`ACTIVE`/`PAUSE` and edits the hook scripts; the `references/STATE.md` `.vine.local/` contract is
-amended there to specify git-anchored resolution and the `ACTIVE`-stays-per-tree split. Phase 1's
+This is folded into **Phase 2 (Discovery & Session Plumbing)** of #52, which relocates `PAUSE` to the
+shared personal root and amends the `references/STATE.md` contract to specify git-anchored resolution
+of that root. (`ACTIVE` does not relocate and the hook scripts are unchanged — see Amendment.) Phase 1's
 composition model is unchanged — `.vine.local/` at the main checkout is still the correct literal
 path; Phase 2 only adds *how a worktree resolves to it*. Considered and rejected: a `~/.vine/<repo-key>/`
 home outside the repo — it also survives clones, but loses in-repo discoverability and complicates
@@ -66,16 +72,38 @@ local-only projects living next to their code; reach for it only if clone-portab
 - Worktree and main-checkout sessions share one profile / personal-overlay set per repo, so the
   silent "no profile here" failure disappears. A cold reader of a worktree that lacks a literal
   `.vine.local/` learns from this record that resolution is git-anchored by design, not missing.
-- `ACTIVE` leaves `.vine.local/`, correcting the conflation of an ephemeral session sentinel with
-  durable personal state; the per-tree git dir is its natural home and keeps the hooks from
-  cross-firing between concurrent worktree sessions.
-- Phase 2 carries a real implementation cost: every command/hook that touches the personal root or
-  `ACTIVE` must resolve via `git rev-parse` (with a non-git fallback) instead of a literal path, and
-  STATE.md's contract is amended. This is the right phase for it — the session plumbing already lives
-  there.
+- `ACTIVE` stays out of `.vine.local/` (the shared personal root), correcting the conflation of an
+  ephemeral session sentinel with durable personal state; `.vine/ACTIVE` is per-worktree by checkout
+  and keeps the hooks from cross-firing between concurrent worktree sessions.
+- Phase 2's implementation cost is narrower than first scoped: only the **shared** personal root needs
+  `git rev-parse --git-common-dir` resolution (discovery, profile, overlays, pause). `ACTIVE` stays a
+  literal `.vine/ACTIVE` with no resolution, so the hook scripts and every command's `ACTIVE` read/write
+  are unchanged. STATE.md's contract is amended for the shared-root resolution.
 - Pairs with the deferred gitignore inversion (`2026-06-16-defer-the-vine-gitignore-inversion-to-the-vine-local-work`):
   the inversion ignores `.vine.local/` at the main checkout, which this resolution model keeps as the
   one shared personal root, so the two remain coherent.
 - A short-term stopgap exists independent of the redesign: symlink a worktree's `.vine/PROFILE.md`
   (or `.vine.local/`) to the main checkout's. Used this cycle to unblock the live worktree; not a
   substitute for git-anchored resolution.
+
+## Amendment (2026-06-22, Slice 5)
+
+The original Decision moved `ACTIVE` into the per-worktree private git dir
+(`$(git rev-parse --git-dir)/vine/ACTIVE`). During Slice 5 we kept it at `.vine/ACTIVE` (gitignored)
+instead. The simpler option was simply not considered when the record was first written.
+
+**Why.** `ACTIVE`'s only hard requirement is to be *per-working-tree* (so worktree B's hooks don't fire
+on worktree A's session). `.vine/` is a **tracked** tree, so each worktree already checks out its own
+working copy — a gitignored `.vine/ACTIVE` therefore exists only in the worktree that wrote it, which
+is per-tree *for free*, with no `git rev-parse` resolution at any command or hook site. The git dir
+would also have worked, but it pushed `git rev-parse` prose into navigate/pause/evolve and the hook
+scripts (a real burden and fumble-risk for a markdown framework) and wrote app state into git's private
+directory, all to avoid one extra gitignore glob.
+
+**Cost accepted.** The track-by-default gitignore inversion is no longer a single `.vine.local/` rule —
+it carries an explicit `.vine/ACTIVE` line alongside it (and the contributor-only `.vine/.trellis-ok`).
+Two simple globs, still far less brittle than the deny-then-allowlist #108 removes.
+
+**Unchanged.** The shared-personal-root anchoring (`dirname "$(git rev-parse --git-common-dir)"` for
+profile, overlays, local projects, pause) — the core fix this record exists for — stands exactly as
+decided.

--- a/.vine/projects/workflow/team-layer/NAVIGATION.md
+++ b/.vine/projects/workflow/team-layer/NAVIGATION.md
@@ -139,7 +139,7 @@ team recommendation glosses #57 (reads without dereferencing).
 
 ### Slice 4: Two-root project discovery — Complete
 **Started**: 2026-06-22 12:15
-**Commit**: pending
+**Commit**: 8cfbfcf
 **Gear**: free-climb
 **Approach taken**: Taught all 8 discovery sites to scan both `.vine/projects/` and
 `.vine.local/projects/` by referencing the single Filtering Convention in `references/STATE.md`
@@ -189,6 +189,70 @@ presented before coding; engineer chose free climb, trusting the approach. No mi
     root-awareness and the git-anchoring the worktree ADR specified. The referential-homes home (one
     Filtering Convention statement) is what kept that from rippling into 8 separate restatements.
 
+### Slice 5: Relocate PAUSE + ACTIVE and update hook scripts — Complete
+**Started**: 2026-06-22 12:40
+**Commit**: pending
+**Gear**: walk-me-through
+**Approach taken**: Two halves. (1) **PAUSE.md relocated** to the feature's mirrored personal path
+`.vine.local/projects/<domain>/<feature-slug>/PAUSE.md` (shared personal root, resolved per *The two
+roots* in STATE.md) — pause state is personal, so it lives under `.vine.local/` even for a shared
+`.vine/projects/` feature. Updated the writer (`pause.md`), the reader (`resume.md`), the consume sites
+(`inquire.md`, `navigate.md`, `evolve.md` session-start + backstop delete), and `init.md`'s archive-sweep
+stray-PAUSE delete. (2) **STATE.md contract** amended for git-anchored resolution of the *shared* personal
+root (`dirname "$(git rev-parse --git-common-dir)"`, cwd fallback), generalizing Slice 4's
+discovery-scoped rule; the Slice-4 Filtering Convention paragraph now references the general rule.
+**Mid-slice design pivot (see Decisions): `ACTIVE` does NOT relocate** — it stays at `.vine/ACTIVE`
+(gitignored), so the hook scripts (`journal-check.sh`, `run-tests.sh`) and every command's `ACTIVE`
+read/write/delete are **unchanged**. STATE.md's `ACTIVE` section, escape hatch, scripts intro, and
+source-of-truth table were rewritten to document `.vine/ACTIVE` (per-worktree-by-checkout) rather than
+the git dir.
+**Deviations from spec**: **`ACTIVE` does not move** — the SPEC Goal (and the original worktree ADR)
+had it relocating to `.vine.local/ACTIVE`, then the per-worktree git dir. We kept `.vine/ACTIVE`
+instead (engineer-directed during the slice). Hooks therefore untouched. Annotated in SPEC (Phase 2
+note + Slice 5 addendum) and the knowledge ADR (Status + Decision + Amendment section). New Slice-9
+obligation introduced: the flipped `.gitignore` must carry an explicit `.vine/ACTIVE` line.
+**Validation**: pass — `sh .vine/scripts/run-tests.sh` 24/24 (incl. journal-check stale→block,
+fresh→allow). Live journal-check against this worktree's real `.vine/ACTIVE`: stale→exit 2, fresh→exit 0,
+escape-hatch message reads `rm .vine/ACTIVE` (matches contract). `sh .vine/scripts/trellis-check.sh`
+exit 0 (11/11 commands, 8 anchor pairs; stamp fresh). The real `trellis-gate` hook correctly blocked a
+test Bash command containing `git commit` before the stamp refresh — gate working as designed. Two
+pre-existing allowlisted `.vine/hooks/` legacy warnings, unrelated.
+**Decisions made during implementation**:
+  - **ACTIVE stays at `.vine/ACTIVE` (gitignored), not the per-worktree git dir** (Option B). The
+    engineer questioned the git-dir choice mid-slice; analysis showed `.vine/` is a tracked tree, so each
+    worktree checks out its own copy and a gitignored `.vine/ACTIVE` is per-tree *for free* — equal
+    correctness, zero `git rev-parse` prose in commands/hooks, no app state written into `.git/`. Cost:
+    one extra gitignore glob at the Slice-9 flip. The original ADR simply hadn't considered it (decided
+    by: engineer — chose Option B after I laid out the tradeoff; confidence: high)
+  - **Amend the ADR in place rather than supersede.** Same-cycle (written hours earlier, commit
+    715393c), and the git-dir half never shipped — superseding would leave a confusing two-ADR trail for
+    a mid-implementation correction. Marked the Status line amended, revised the Decision bullet, added an
+    Amendment section; the shared-root anchoring (the ADR's core) is unchanged (decided by: claude —
+    recommended, engineer asked "what about the ADR?"; confidence: high)
+  - **PAUSE.md always at `.vine.local/projects/<d>/<f>/`** even for shared projects, stated as the
+    feature's "mirrored personal path"; sites reference the two-roots resolution rather than restating
+    the common-dir mechanics (referential-homes) (decided by: claude; confidence: high)
+  - **Scope held:** `.resolved` marker path (evolve.md:521) and evolve's archive destination left
+    root-unaware for now — that's Slice 8 (evolve local→shared) territory, not PAUSE/ACTIVE (decided by:
+    claude; confidence: medium)
+**Acceptance criteria**:
+  - [x] AC4 — **intent over letter.** The criterion's letter named `.vine.local/ACTIVE`; the design
+    evolved to `.vine/ACTIVE`. Intent (navigate writes the sentinel, `journal-check.sh`/`run-tests.sh`
+    read it, the active-session hook fires correctly per-worktree) is met and verified live. The hooks
+    read `.vine/ACTIVE` (unchanged); the cross-worktree correctness comes from per-tree checkout.
+  - [x] AC5 — `vine:pause` writes `PAUSE.md` under `.vine.local/projects/...`; resume/inquire/navigate/
+    evolve consume it from there; consumed-once rule intact.
+**Engineer feedback incorporated**: The engineer challenged putting `ACTIVE` in the git dir ("does it
+make sense?"), which drove the pivot to Option B and the ADR amendment — the central shape of this slice.
+**Learnings**:
+  - Engineer → Claude: Question an inherited design decision before implementing it, even one you
+    co-authored days ago — the git-dir relocation was solving a problem (`.vine/ACTIVE` being tracked
+    post-flip) that a one-line gitignore solves far more cheaply. An ADR being Accepted doesn't make its
+    every sub-decision load-bearing.
+  - Claude → Engineer: When a tracked directory is checked out per worktree, a gitignored file inside it
+    is *already* per-worktree — no git-dir gymnastics needed. The two-scope split (shared vs per-tree) the
+    ADR identified is real, but only the *shared* scope actually needs git resolution.
+
 ### Handoff note for Slice 9 (init Upgrade Mode)
 Upgrade Mode should offer to relocate a legacy `.vine/context/*.local.md` → `.vine.local/context/*.md`
 (suffix dropped) for repos tracking `main`. This is a courtesy migration, not a shipped-version compat
@@ -206,10 +270,11 @@ need — the personal-layer convention never shipped (see Slice 2 decision). Dec
     pause/navigate/evolve delete the same path, journal-check.sh/run-tests.sh read it), so the runtime
     is self-consistent; only STATE.md's contract documents the end-state. Fixing `evolve.md:64` in
     isolation now would BREAK it (delete the wrong path while navigate still writes the old one).
-  - **Slice 5 (Phase 2) ACTIVE-relocation checklist** — move all of these from `.vine/ACTIVE` →
-    `.vine.local/ACTIVE` together: `navigate.md:79` (writer) + `:384/:416/:478/:557` (leave/delete),
-    `pause.md:100` (delete), `evolve.md:64` (delete), `journal-check.sh:12` (+ line 4 comment, line 63
-    escape-hatch message), `run-tests.sh:35`. Same slice relocates PAUSE.md to `.vine.local/projects/...`.
+  - **Slice 5 ACTIVE-relocation checklist — SUPERSEDED (done differently).** This planned to move
+    `.vine/ACTIVE` → `.vine.local/ACTIVE`. Slice 5 instead kept `ACTIVE` at `.vine/ACTIVE` (Option B —
+    gitignored, per-worktree by checkout), so none of those `navigate/pause/evolve` lines or the hook
+    scripts (`journal-check.sh`/`run-tests.sh`) moved. PAUSE.md *was* relocated to
+    `.vine.local/projects/...`. See the Slice 5 entry + ADR Amendment.
   - **PR 1 reviewer note**: STATE.md documents the `.vine.local/` end-state (ACTIVE/PAUSE/PROFILE/
     gitignore) ahead of the command + hook machinery, which relocates in Phases 2-3. This is the
     intended "contract leads implementation" phasing (maintainer-directed in Slice 1), not drift.
@@ -226,8 +291,10 @@ need — the personal-layer convention never shipped (see Slice 2 decision). Dec
     AND the directory **table** (`PROFILE.md` / `ACTIVE`,`PAUSE.md` rows ~304/306). The post-Phase-1
     ref-hygiene pass updated only the customize bullet + team-distribution block to `.vine.local/`,
     so the scaffold now names both conventions — Slice 10 must close the entire block, not just the
-    table. Gated on Phase 2's final locations (per the worktree ADR, `ACTIVE` lands in the
-    per-worktree git dir, NOT `.vine.local/` — don't bake `.vine.local/ACTIVE` into the table).
+    table. Phase 2's final locations are now settled: `ACTIVE` stays at `.vine/ACTIVE` (gitignored,
+    per-worktree) — the table should keep an `ACTIVE` → `.vine/ACTIVE` row, and PAUSE.md moves to
+    `.vine.local/projects/<d>/<f>/`. Also: **Slice 9 must add a `.vine/ACTIVE` line to the flipped
+    `.gitignore`** (alongside `.vine.local/` and the contributor-only `.vine/.trellis-ok`).
     Plus shared.md's gitignore-tracking note (~line 70/82), CLAUDE.md, README.md, and STATE.md's
     surfaces per the State Artifact Addition Checklist. (Surfaced by the cold vine-reviewer pass on
     PR #122.)

--- a/.vine/projects/workflow/team-layer/NAVIGATION.md
+++ b/.vine/projects/workflow/team-layer/NAVIGATION.md
@@ -191,7 +191,7 @@ presented before coding; engineer chose free climb, trusting the approach. No mi
 
 ### Slice 5: Relocate PAUSE + ACTIVE and update hook scripts — Complete
 **Started**: 2026-06-22 12:40
-**Commit**: pending
+**Commit**: 0833865
 **Gear**: walk-me-through
 **Approach taken**: Two halves. (1) **PAUSE.md relocated** to the feature's mirrored personal path
 `.vine.local/projects/<domain>/<feature-slug>/PAUSE.md` (shared personal root, resolved per *The two
@@ -252,6 +252,42 @@ make sense?"), which drove the pivot to Option B and the ADR amendment — the c
   - Claude → Engineer: When a tracked directory is checked out per worktree, a gitignored file inside it
     is *already* per-worktree — no git-dir gymnastics needed. The two-scope split (shared vs per-tree) the
     ADR identified is real, but only the *shared* scope actually needs git resolution.
+
+### Slice 6: Per-path commit test — Complete
+**Started**: 2026-06-22 13:05
+**Commit**: pending
+**Gear**: walk-me-through (ran in approve-edits continuity from Slice 5; no separate gear prompt —
+the slice is trivially mechanical, a process note not a redirection)
+**Approach taken**: Replaced the root `git check-ignore -q .vine/projects` test with the per-path test
+(run `git check-ignore` against the **specific feature directory**) at every commit/move decision:
+`verify.md` (CONTEXT+MAP first commit), `inquire.md` (SPEC commit), `navigate.md` (slice commit 4c +
+phase-group boundary), `evolve.md` (archive `git mv`-vs-`mv` + EVOLUTION/.resolved commit). Each site
+now references STATE.md's *Committing Artifacts* per-path rule (which Slice 1 already wrote) rather than
+restating the mechanics, and frames the gitignored case as "a local project under `.vine.local/projects/`."
+**Deviations from spec**: None. Scoped to the four commit-test sites. The evolve archive *destination*
+(`.vine/projects/.archive/` hardcoded, line 544) and the `.resolved` marker path are left root-unaware —
+that's Slice 8 (evolve local→shared) territory, consistent with the Slice 5 scope note.
+**Validation**: pass — `sh .vine/scripts/trellis-check.sh` exit 0 (11/11 commands, 8 anchor pairs;
+`.vine/.trellis-ok` stamped pass). Prose-only change (no scripts/tests touched). Confirmed by grep that
+no `check-ignore -q .vine/projects` root test remains in any command. Two pre-existing allowlisted
+`.vine/hooks/` warnings, unrelated.
+**Decisions made during implementation**:
+  - Reference STATE.md's *Committing Artifacts* per-path rule at each site rather than restate the
+    `git check-ignore` mechanics (referential-homes — the rule has one authoritative home from Slice 1)
+    (decided by: claude; confidence: high)
+  - Leave evolve's archive destination + `.resolved` path root-unaware for Slice 8; Slice 6 is the
+    commit *test*, not evolve's local-project handling (decided by: claude; confidence: high)
+**Acceptance criteria**:
+  - [x] AC7 — the commit-or-skip test runs against the specific feature directory in
+    verify/inquire/navigate/evolve, so shared projects (`.vine/projects/`) commit and local ones
+    (`.vine.local/projects/`) skip, with no `.vine/projects/` root special-casing
+**Engineer feedback incorporated**: Engineer chose "continue in this session" to finish Phase 2;
+approve-edits continuity from Slice 5 (each edit reviewed as it landed).
+**Learnings**:
+  - Engineer → Claude: (none new this slice)
+  - Claude → Engineer: Because Slice 1 homed the per-path rule in STATE.md's *Committing Artifacts*,
+    Slice 6 was a pure reference-the-rule pass — the upfront referential-homes investment paid off as a
+    mechanical, low-risk close to Phase 2.
 
 ### Handoff note for Slice 9 (init Upgrade Mode)
 Upgrade Mode should offer to relocate a legacy `.vine/context/*.local.md` → `.vine.local/context/*.md`

--- a/.vine/projects/workflow/team-layer/NAVIGATION.md
+++ b/.vine/projects/workflow/team-layer/NAVIGATION.md
@@ -255,7 +255,7 @@ make sense?"), which drove the pivot to Option B and the ADR amendment — the c
 
 ### Slice 6: Per-path commit test — Complete
 **Started**: 2026-06-22 13:05
-**Commit**: pending
+**Commit**: d80a95e
 **Gear**: walk-me-through (ran in approve-edits continuity from Slice 5; no separate gear prompt —
 the slice is trivially mechanical, a process note not a redirection)
 **Approach taken**: Replaced the root `git check-ignore -q .vine/projects` test with the per-path test

--- a/.vine/projects/workflow/team-layer/NAVIGATION.md
+++ b/.vine/projects/workflow/team-layer/NAVIGATION.md
@@ -137,6 +137,58 @@ team recommendation glosses #57 (reads without dereferencing).
     moves only the reader silently breaks the feature; the SPEC's per-slice file lists are a guide, not
     a hard partition when correctness spans them.
 
+### Slice 4: Two-root project discovery — Complete
+**Started**: 2026-06-22 12:15
+**Commit**: pending
+**Gear**: free-climb
+**Approach taken**: Taught all 8 discovery sites to scan both `.vine/projects/` and
+`.vine.local/projects/` by referencing the single Filtering Convention in `references/STATE.md`
+rather than restating the filter rules per site (referential-homes stance). Sites updated:
+`status.md` (preserved its "include resolved, marked" exception), `pause.md`, `resume.md`,
+`navigate.md`, `inquire.md`, `evolve.md`, `init.md`'s archive sweep, and `.claude/commands/trellis.md`'s
+Glob (Step 5b). Amended STATE.md's Filtering Convention with a **Resolving the personal root**
+paragraph: the gitignored `.vine.local/` is resolved at the repository's *primary* worktree via
+`git rev-parse --git-common-dir` (cwd fallback for non-git dirs) so worktree sessions enumerate the
+same local-only projects instead of silently finding none — the discovery half of the worktree ADR.
+Made `init.md`'s archive sweep root-aware (each project archives within its own root's `.archive/`;
+the existing `git mv`/plain-`mv` branch maps cleanly to shared/local). Folded in the Slice-3
+profile-path leftover in trellis (`.vine/PROFILE.md` → `.vine.local/PROFILE.md`, 3 refs).
+**Deviations from spec**: Two bounded additions beyond the literal "discovery" scope, both for
+correctness in the same code paths I was already editing: (1) `init.md` archive-sweep *destination*
+made root-aware (not just the *scan*), else a local project would archive into the shared
+`.vine/projects/.archive/`; (2) the trellis profile-path fix, a Slice-3 leftover (AC3's profile move)
+surfaced because trellis's discovery section was in scope here. Recorded, not silent.
+**Validation**: pass — `sh .vine/scripts/trellis-check.sh` exit 0 (11/11 commands, 8 cross-ref anchor
+pairs; `.vine/.trellis-ok` stamped pass at 12:33, fresh after all edits). Artifact validation
+unaffected — Slice 4 touched no artifact files and no STATE.md template fences, so the parsed
+templates and the feature's artifacts (validated in prior slices) are unchanged. The two pre-existing
+allowlisted `.vine/hooks/` legacy warnings (init.md:104-105) are unrelated.
+**Decisions made during implementation**:
+  - Scope Slice 4's STATE.md amendment to the **Filtering Convention** (discovery's git-anchored
+    resolution of the personal root) and leave the general two-roots contract + the `ACTIVE` per-tree
+    git-dir split entirely to Slice 5 — keeps STATE.md internally non-contradictory at every step (no
+    half-changed `ACTIVE` contract), unlike the broad Slice-1 consolidation (decided by: claude, after
+    flagging the alternative to the engineer; confidence: high)
+  - Make each site a thin reference to the Filtering Convention while preserving its distinct tail
+    (status includes-resolved, pause "nothing active to pause", resume/inquire/evolve `/vine:verify`
+    suggestion) rather than a uniform boilerplate swap (decided by: claude; confidence: high)
+  - Fold the trellis `.vine/PROFILE.md` → `.vine.local/PROFILE.md` fix into this slice since trellis's
+    discovery section was already open, rather than leave a known Slice-3 gap (decided by: claude —
+    flagged in preview; confidence: high)
+**Acceptance criteria**:
+  - [x] AC6 — all feature-enumerating commands (status, resume, pause, navigate, inquire, evolve,
+    init's archive sweep) and trellis discover projects in **both** roots with `.resolved`/`.archive/`
+    filtering applied to each; the two-root rule is stated once (Filtering Convention) and referenced,
+    not restated per site
+**Engineer feedback incorporated**: Gear choice (free climb) and the two flagged judgment calls were
+presented before coding; engineer chose free climb, trusting the approach. No mid-slice redirection.
+**Learnings**:
+  - Engineer → Claude: (none new this slice)
+  - Claude → Engineer: A "discovery" slice can't cleanly stop at the *scan* — the archive *destination*
+    and the personal-root *resolution* live in the same code paths, so getting discovery right pulls in
+    root-awareness and the git-anchoring the worktree ADR specified. The referential-homes home (one
+    Filtering Convention statement) is what kept that from rippling into 8 separate restatements.
+
 ### Handoff note for Slice 9 (init Upgrade Mode)
 Upgrade Mode should offer to relocate a legacy `.vine/context/*.local.md` → `.vine.local/context/*.md`
 (suffix dropped) for repos tracking `main`. This is a courtesy migration, not a shipped-version compat

--- a/.vine/projects/workflow/team-layer/PROJECT-MAP.md
+++ b/.vine/projects/workflow/team-layer/PROJECT-MAP.md
@@ -16,5 +16,5 @@
 | Phase | Slices | Status | PR |
 |-------|--------|--------|----|
 | Phase 1: Composition Model | 1-3 | ✅ Complete | [#122](https://github.com/moduloMoments/VINE/pull/122) |
-| Phase 2: Discovery & Session Plumbing | 4-6 | ⬜ Pending | — |
+| Phase 2: Discovery & Session Plumbing | 4-6 | 🚧 Active | — |
 | Phase 3: Visibility, the Flip & Docs | 7-10 | ⬜ Pending | — |

--- a/.vine/projects/workflow/team-layer/PROJECT-MAP.md
+++ b/.vine/projects/workflow/team-layer/PROJECT-MAP.md
@@ -16,5 +16,5 @@
 | Phase | Slices | Status | PR |
 |-------|--------|--------|----|
 | Phase 1: Composition Model | 1-3 | ✅ Complete | [#122](https://github.com/moduloMoments/VINE/pull/122) |
-| Phase 2: Discovery & Session Plumbing | 4-6 | ✅ Complete | — |
+| Phase 2: Discovery & Session Plumbing | 4-6 | ✅ Complete | [#123](https://github.com/moduloMoments/VINE/pull/123) |
 | Phase 3: Visibility, the Flip & Docs | 7-10 | ⬜ Pending | — |

--- a/.vine/projects/workflow/team-layer/PROJECT-MAP.md
+++ b/.vine/projects/workflow/team-layer/PROJECT-MAP.md
@@ -16,5 +16,5 @@
 | Phase | Slices | Status | PR |
 |-------|--------|--------|----|
 | Phase 1: Composition Model | 1-3 | ✅ Complete | [#122](https://github.com/moduloMoments/VINE/pull/122) |
-| Phase 2: Discovery & Session Plumbing | 4-6 | 🚧 Active | — |
+| Phase 2: Discovery & Session Plumbing | 4-6 | ✅ Complete | — |
 | Phase 3: Visibility, the Flip & Docs | 7-10 | ⬜ Pending | — |

--- a/.vine/projects/workflow/team-layer/SPEC.md
+++ b/.vine/projects/workflow/team-layer/SPEC.md
@@ -183,6 +183,15 @@ site.
 **Acceptance criteria**: AC6.
 **Complexity signal**: Medium — many sites, but mechanical once the convention is referenced.
 
+> **Addendum (implemented 2026-06-22):** Slice 4 also made two bounded corrections in code paths it
+> was already editing, beyond the literal "scan" scope: (1) `init.md`'s archive-sweep *destination* is
+> now root-aware — a project archives within its own root's `.archive/` (the `git mv`/plain-`mv` branch
+> maps to shared/local), not always `.vine/projects/.archive/`; (2) trellis's profile path was corrected
+> to `.vine.local/PROFILE.md` (a leftover from Slice 3's AC3 profile move, surfaced because trellis's
+> discovery section was in scope). STATE.md's Slice-4 amendment is scoped to the **Filtering Convention**
+> (personal-root resolution via `git rev-parse --git-common-dir`); the general two-roots contract and the
+> `ACTIVE` per-tree split remain Slice 5's, so STATE.md stays internally consistent at each step.
+
 ### Slice 5: Relocate PAUSE + ACTIVE and update hook scripts
 **Goal**: pause writes `PAUSE.md` under `.vine.local/projects/<d>/<f>/`; resume and the consume
 sites (inquire/navigate/evolve) read it there. navigate writes `.vine.local/ACTIVE`

--- a/.vine/projects/workflow/team-layer/SPEC.md
+++ b/.vine/projects/workflow/team-layer/SPEC.md
@@ -164,12 +164,18 @@ Session boundary: After this phase, all commands operate correctly across both r
 **Added 2026-06-22 (worktree resolution — see knowledge ADR
 `2026-06-22-anchor-the-personal-root-at-the-repo-shared-across-worktrees`):** gitignored personal
 state is invisible to git worktrees/clones (a worktree session can't see the main checkout's
-`.vine.local/`). Phase 2 must resolve the personal root from git, not cwd: the **shared** personal
-root (profile, overlays, local projects, pause) anchors at the primary worktree via
-`git rev-parse --git-common-dir`, while the **`ACTIVE`** sentinel moves to the per-worktree git dir
-(`git rev-parse --git-dir`) so hooks don't cross-fire between worktrees. Non-git dirs fall back to
-cwd-relative. This extends Slice 4 (discovery resolves the shared root) and Slice 5 (ACTIVE/PAUSE
-relocation uses the git anchors); STATE.md's `.vine.local/` contract is amended here to match.
+`.vine.local/`). Phase 2 must resolve the **shared** personal root (profile, overlays, local projects,
+pause) from git, not cwd: it anchors at the primary worktree via `git rev-parse --git-common-dir`
+(non-git dirs fall back to cwd-relative). This extends Slice 4 (discovery resolves the shared root) and
+Slice 5 (PAUSE relocation uses the git-anchored shared root); STATE.md's `.vine.local/` contract is
+amended across both to match.
+
+> **Amended 2026-06-22 (Slice 5):** the ADR originally moved the **`ACTIVE`** sentinel to the
+> per-worktree git dir (`git rev-parse --git-dir`). During implementation we kept it at `.vine/ACTIVE`
+> (gitignored) instead — `.vine/` is tracked, so each worktree checks out its own copy and a gitignored
+> `.vine/ACTIVE` is per-tree for free, with **no** `git rev-parse` and **no** hook-script changes. Cost:
+> the Slice-9 gitignore flip carries an explicit `.vine/ACTIVE` rule alongside `.vine.local/`. The ADR's
+> Status + Decision + an Amendment section record this; the shared-root anchoring is unchanged.
 
 ### Slice 4: Two-root project discovery
 **Goal**: Extend the 7 prose scan sites (status, resume, pause, navigate, inquire, evolve, init's
@@ -202,6 +208,18 @@ location.
 `.vine/scripts/journal-check.sh`, `.vine/scripts/run-tests.sh`.
 **Acceptance criteria**: AC4, AC5.
 **Complexity signal**: Medium — hook scripts must move in lockstep with navigate's writer.
+
+> **Addendum (implemented 2026-06-22): ACTIVE does not relocate.** The Goal above assumed
+> `ACTIVE` moves to `.vine.local/ACTIVE` (per the original worktree ADR, then the git dir). During
+> implementation we kept it at `.vine/ACTIVE` (gitignored) — see the Phase 2 amendment note above and
+> the ADR's Amendment section. Consequences for this slice: **the hook scripts are NOT touched**
+> (`journal-check.sh`/`run-tests.sh` already read `.vine/ACTIVE`), and navigate/pause/evolve's `ACTIVE`
+> read/write/delete lines are unchanged. The slice's *real* work was (a) relocating `PAUSE.md` to the
+> feature's mirrored personal path `.vine.local/projects/<d>/<f>/PAUSE.md` across pause/resume/inquire/
+> navigate/evolve (+ init's archive-sweep stray-PAUSE delete), and (b) amending STATE.md's two-roots
+> contract for the shared-root git-anchored resolution while clarifying `ACTIVE` stays at `.vine/ACTIVE`.
+> AC4 is met by the unchanged-but-now-documented `.vine/ACTIVE` machinery + the contract; AC5 by the
+> PAUSE relocation. **Slice 9 must add a `.vine/ACTIVE` line to the flipped `.gitignore`.**
 
 ### Slice 6: Per-path commit test
 **Goal**: Replace the `git check-ignore -q .vine/projects` root test (`verify.md:331`,

--- a/.vine/projects/workflow/team-layer/SPEC.md
+++ b/.vine/projects/workflow/team-layer/SPEC.md
@@ -155,7 +155,7 @@ command "Load Engineer Profile" references.
 (Reference Legibility).
 **Complexity signal**: Low.
 
-## Phase 2: Discovery & Session Plumbing (Slices 4-6) ⬜
+## Phase 2: Discovery & Session Plumbing (Slices 4-6) ✅
 Summary: Make every command find projects in both roots, relocate the session-state files
 (PAUSE/ACTIVE) and update the hook scripts that read them, and switch the commit test to per-path.
 Session boundary: After this phase, all commands operate correctly across both roots while the

--- a/commands/vine/evolve.md
+++ b/commands/vine/evolve.md
@@ -59,8 +59,10 @@ If PROJECT-MAP.md exists, update the evolve row to 🚧 with today's date. If it
 table, note which phases shipped in prior PRs — evolve's verification should focus on the final
 phase group and cross-phase integration, not re-verify already-shipped work.
 
-If the feature directory contains a PAUSE.md, picking the work back up consumes it: surface
-its notes, then delete the file — a consumed pause must not linger suggesting `/vine:resume`.
+If the feature's mirrored personal path (`.vine.local/projects/<domain>/<feature-slug>/PAUSE.md`,
+resolved per *The two roots* in `references/STATE.md`) contains a PAUSE.md, picking the work back up
+consumes it: surface its notes, then delete the file — a consumed pause must not linger suggesting
+`/vine:resume`.
 Also delete `.vine/ACTIVE` (repo root) if it exists: any navigate session on this feature is
 over, and a stale sentinel keeps installed hooks firing against work that's no longer active
 (format and lifecycle in `references/STATE.md`).
@@ -519,7 +521,8 @@ Options (mutually exclusive):
 
 If the engineer chooses to resolve, write an empty `.resolved` file to
 `.vine/projects/<domain>/<feature-slug>/.resolved`. Then consume any
-`.vine/projects/<domain>/<feature-slug>/PAUSE.md` that still exists — the backstop delete. Evolve's
+`.vine.local/projects/<domain>/<feature-slug>/PAUSE.md` (the mirrored personal path) that still
+exists — the backstop delete. Evolve's
 session-start consumption normally removed it already, so a PAUSE.md surviving to here appeared
 *after* evolve began and its notes aren't necessarily stale: surface them to the engineer first,
 then delete the file. Never delete it silently — the same surface-then-delete rule the other

--- a/commands/vine/evolve.md
+++ b/commands/vine/evolve.md
@@ -39,12 +39,12 @@ ship — every feature is an opportunity to grow on three dimensions.
 
 ## Getting Started
 
-Identify the feature directory under `.vine/projects/` (e.g., `.vine/projects/payments/webhook-support/`). If
-there are multiple feature directories, use `AskUserQuestion` to let the engineer pick which
-feature to review. Filter out resolved projects (directories containing a `.resolved` file) and
-archived projects (under `.vine/projects/.archive/`). If all projects are resolved or archived,
-tell the engineer and suggest starting a new cycle with `/vine:verify` — present the command
-in its own fenced code block so it's copy-pastable.
+Identify the feature directory per the Filtering Convention in `references/STATE.md` (both roots —
+e.g. `.vine/projects/payments/webhook-support/` or `.vine.local/projects/...` — with resolved and
+`.archive/` subtrees filtered out). If there are multiple feature directories, use `AskUserQuestion`
+to let the engineer pick which feature to review. If all projects are resolved or archived, tell
+the engineer and suggest starting a new cycle with `/vine:verify` — present the command in its own
+fenced code block so it's copy-pastable.
 
 Read all VINE artifacts for this feature:
 - `.vine/projects/<domain>/<feature-slug>/CONTEXT.md` (the landscape)

--- a/commands/vine/evolve.md
+++ b/commands/vine/evolve.md
@@ -537,8 +537,9 @@ Options (mutually exclusive):
 1. "Archive now (Recommended)" — "Move the project under `.vine/projects/.archive/`"
 2. "Keep in place" — "Leave it resolved-but-unarchived; archive later by hand"
 
-If the engineer archives, move the project directory — `git mv` when the repo tracks artifacts so
-history follows, plain `mv` when untracked:
+If the engineer archives, move the project directory — `git mv` when this feature directory is
+tracked (the per-path `git check-ignore` test — see *Committing Artifacts* in `references/STATE.md`)
+so history follows, plain `mv` when it's gitignored (a local project):
 
 ```
 mkdir -p .vine/projects/.archive/<domain>
@@ -560,8 +561,9 @@ under *Committing Artifacts*):
 - **CLAUDE.md** and **`.vine/context/`** overlay updates (if accepted) — ordinary tracked repo
   files; commit them whenever they change, regardless of the artifact-tracking choice.
 - **EVOLUTION.md** and the **`.resolved`** marker (if resolved) — VINE artifacts; stage them
-  **only when the repo tracks `.vine/` artifacts**. When artifacts are untracked (gitignored, or
-  a personal scope) they update on disk but stay out of the commit.
+  **only when this feature directory is tracked** (the per-path test). When the feature directory is
+  gitignored (a local project under `.vine.local/projects/`) they update on disk but stay out of the
+  commit.
 - **`.vine.local/PROFILE.md`** updates (if accepted) — commonly gitignored (it's personal); stage only
   if the repo tracks it.
 

--- a/commands/vine/init.md
+++ b/commands/vine/init.md
@@ -618,8 +618,9 @@ offer, no mention. Otherwise list them and offer to archive them, mirroring evol
    git mv <root>/projects/<domain>/<feature-slug> <root>/projects/.archive/<domain>/<feature-slug>
    ```
 
-   Before moving, delete any stray `PAUSE.md` in a resolved project — a resolved project's pause
-   state is definitionally stale (consumed-once rule). **`.vine/knowledge/<domain>/` records are
+   Before moving, delete any stray `PAUSE.md` at the project's mirrored personal path
+   (`.vine.local/projects/<domain>/<feature-slug>/PAUSE.md`) — a resolved project's pause state is
+   definitionally stale (consumed-once rule). **`.vine/knowledge/<domain>/` records are
    never moved** — they live outside `.vine/projects/` and keep their own Accepted→Superseded
    lifecycle, so durable judgment outlives the archived project.
 

--- a/commands/vine/init.md
+++ b/commands/vine/init.md
@@ -593,15 +593,15 @@ resolved before that offer existed (or where the engineer declined it) sit
 **resolved-but-unarchived** forever, with no command that will ever sweep them. Init closes
 that gap.
 
-Scan `.vine/projects/` for directories containing a `.resolved` marker that are **not already
-under `.vine/projects/.archive/`**. If none, skip silently — no offer, no mention. Otherwise
-list them and offer to archive them, mirroring evolve's archive mechanics (lifecycle in
-`references/STATE.md`, "Project Lifecycle"):
+Scan both roots per the Filtering Convention in `references/STATE.md` for directories containing a
+`.resolved` marker that are **not already under an `.archive/` subtree**. If none, skip silently — no
+offer, no mention. Otherwise list them and offer to archive them, mirroring evolve's archive mechanics
+(lifecycle in `references/STATE.md`, "Project Lifecycle"):
 
 1. **Present the list** of resolved-but-unarchived projects (`<domain>/<feature-slug>`), then
    offer via `AskUserQuestion` (`multiSelect: false`):
-   - **"Archive all N (Recommended)"** — description: "Move every resolved project under
-     `.vine/projects/.archive/` — gets completed work fully out of the way"
+   - **"Archive all N (Recommended)"** — description: "Move every resolved project under its root's
+     `.archive/` — gets completed work fully out of the way"
    - **"Pick which to archive"** — description: "Choose a subset"
    - **"Not now"** — description: "Leave them resolved-but-unarchived — nothing changes on disk"
 
@@ -609,12 +609,13 @@ list them and offer to archive them, mirroring evolve's archive mechanics (lifec
    `AskUserQuestion` (`multiSelect: true`); when there are more than four, split across calls
    by domain (max 4 options per call, per the Interaction Constraints in `shared.md`).
 
-3. **Move each accepted project** — `git mv` when the repo tracks artifacts so history follows,
-   plain `mv` when untracked:
+3. **Move each accepted project within its own root** (`<root>` is `.vine` for a shared project,
+   `.vine.local` for a local one) — `git mv` when the repo tracks the artifact so history follows
+   (shared projects), plain `mv` when untracked (local projects):
 
    ```
-   mkdir -p .vine/projects/.archive/<domain>
-   git mv .vine/projects/<domain>/<feature-slug> .vine/projects/.archive/<domain>/<feature-slug>
+   mkdir -p <root>/projects/.archive/<domain>
+   git mv <root>/projects/<domain>/<feature-slug> <root>/projects/.archive/<domain>/<feature-slug>
    ```
 
    Before moving, delete any stray `PAUSE.md` in a resolved project — a resolved project's pause

--- a/commands/vine/inquire.md
+++ b/commands/vine/inquire.md
@@ -63,8 +63,10 @@ If CONTEXT.md exists, read it and summarize the key points back to the engineer:
 > "Based on our verify phase, here's what I'm working with: [brief summary]. The open questions
 > were: [list]. Let's start by resolving those."
 
-**Consume any pause state.** If the feature directory contains a PAUSE.md (e.g., the engineer
-paused after verify), surface its notes alongside the summary above, then delete it — the
+**Consume any pause state.** If the feature's mirrored personal path
+(`.vine.local/projects/<domain>/<feature-slug>/PAUSE.md`, resolved per *The two roots* in
+`references/STATE.md`) contains a PAUSE.md (e.g., the engineer paused after verify), surface its
+notes alongside the summary above, then delete it — the
 consumed-once rule (see `references/STATE.md`). A consumed pause must not linger: it would keep
 suggesting `/vine:resume` for work that has already resumed. Anything worth keeping past this
 session belongs in the artifacts, not PAUSE.md. (If no PAUSE.md is present, skip.)

--- a/commands/vine/inquire.md
+++ b/commands/vine/inquire.md
@@ -313,10 +313,11 @@ Once approved:
 
 1. Update PROJECT-MAP.md (if it exists) — set the inquire row to ✅ with today's date.
 
-2. If the repo tracks artifacts (`git check-ignore -q .vine/projects` exits non-zero), commit
-   SPEC.md and the PROJECT-MAP.md update (see "Committing Artifacts" in `references/STATE.md`).
-   If the path is gitignored, skip this step silently — personal-scope artifacts never enter
-   a commit.
+2. If this feature directory is tracked (run `git check-ignore -q` against the **specific feature
+   directory** — the per-path test in "Committing Artifacts", `references/STATE.md` — and it exits
+   non-zero), commit SPEC.md and the PROJECT-MAP.md update. If the feature directory is gitignored
+   (a local project under `.vine.local/projects/`), skip this step silently — personal-scope
+   artifacts never enter a commit.
 
 3. Persist actionable retro items before printing the completion block. The retro is
    conversation output and doesn't survive `/clear` — if a retro item should change what

--- a/commands/vine/inquire.md
+++ b/commands/vine/inquire.md
@@ -41,13 +41,13 @@ decide, and document everything. The output is a SPEC.md that vine:navigate can 
 
 ### 1. Load the Context
 
-Identify the feature directory under `.vine/projects/`. Look for the domain/feature-slug path
-(e.g., `.vine/projects/payments/webhook-support/`). Filter out resolved projects (directories
-containing a `.resolved` file) and archived projects (under `.vine/projects/.archive/`). If
-there's only one active feature directory, use that. If there are multiple, use
-`AskUserQuestion` to let the engineer pick which feature to work on. If all projects are
-resolved or archived, tell the engineer and suggest starting a new cycle with `/vine:verify` —
-present the command in its own fenced code block so it's copy-pastable.
+Identify the feature directory per the Filtering Convention in `references/STATE.md` (both roots —
+look for the domain/feature-slug path, e.g. `.vine/projects/payments/webhook-support/` or
+`.vine.local/projects/...` — with resolved and `.archive/` subtrees filtered out). If there's only
+one active feature directory, use that. If there are multiple, use `AskUserQuestion` to let the
+engineer pick which feature to work on. If all projects are resolved or archived, tell the engineer
+and suggest starting a new cycle with `/vine:verify` — present the command in its own fenced code
+block so it's copy-pastable.
 
 Also read `.vine/projects/<domain>/<feature-slug>/PROJECT-MAP.md` if it exists. If present, update the
 inquire row to 🚧 with today's date. If it doesn't exist, skip — older projects won't have one.

--- a/commands/vine/navigate.md
+++ b/commands/vine/navigate.md
@@ -57,12 +57,12 @@ your approach, and teaching you things about the domain that make the implementa
 
 ### 1. Load Context and Spec
 
-Identify the feature directory under `.vine/projects/` (e.g., `.vine/projects/payments/webhook-support/`). If
-there are multiple feature directories, use `AskUserQuestion` to let the engineer pick which
-feature to work on. Filter out resolved projects (directories containing a `.resolved` file) and
-archived projects (under `.vine/projects/.archive/`). If all projects are resolved or archived,
-tell the engineer and suggest starting a new cycle with `/vine:verify` — present the command
-in its own fenced code block so it's copy-pastable.
+Identify the feature directory per the Filtering Convention in `references/STATE.md` (both roots —
+e.g. `.vine/projects/payments/webhook-support/` or `.vine.local/projects/...` — with resolved and
+`.archive/` subtrees filtered out). If there are multiple feature directories, use `AskUserQuestion`
+to let the engineer pick which feature to work on. If all projects are resolved or archived, tell
+the engineer and suggest starting a new cycle with `/vine:verify` — present the command in its own
+fenced code block so it's copy-pastable.
 
 Read `.vine/projects/<domain>/<feature-slug>/CONTEXT.md` and `.vine/projects/<domain>/<feature-slug>/SPEC.md`. If either is
 missing, tell the engineer which prior phase needs to run first.

--- a/commands/vine/navigate.md
+++ b/commands/vine/navigate.md
@@ -289,11 +289,12 @@ and the journal-schema contract behind them — is in `references/STATE.md`.
 
 **c. Commit the slice**
 
-Stage the changed files and commit with this format. **When the repo tracks `.vine/`
-artifacts**, bundle this slice's artifact updates into the same commit so the tracked spec and
-journal never lag the code: the slice's NAVIGATION.md journal entry plus any SPEC.md deviation
-annotations you made during the slice (step 6). **When artifacts are untracked** — many repos
-gitignore them, or keep them in a personal scope, which is fine — commit code only; the
+Stage the changed files and commit with this format. **When this feature directory is tracked**
+(the per-path `git check-ignore` test — see *Committing Artifacts* in `references/STATE.md`),
+bundle this slice's artifact updates into the same commit so the tracked spec and journal never lag
+the code: the slice's NAVIGATION.md journal entry plus any SPEC.md deviation annotations you made
+during the slice (step 6). **When the feature directory is gitignored** — a local project under
+`.vine.local/projects/`, which is fine — commit code only; the
 journal-before-commit guarantee compares file modification time, not commit contents, so it holds
 either way. Never force-add a gitignored artifact. (The full per-commit-point breakdown —
 slice / phase-group boundary / evolve / PR — lives in `references/STATE.md` under *Committing
@@ -463,10 +464,10 @@ phase group boundary before showing the completion block:
 3. Update the SPEC.md phase group header — replace the `⬜` or `🚧` marker with `✅`.
 4. If there's a next phase, update its Milestones row to `🚧 Active`.
 
-   **When the repo tracks artifacts**, commit these tracker updates at the boundary — the
-   PROJECT-MAP.md row changes and the SPEC.md phase-group ✅ marker are the phase group's
-   closing artifact state, so the PR you open next carries them alongside the code. (Untracked
-   repos: they update on disk only, never in a commit.)
+   **When this feature directory is tracked** (the per-path test), commit these tracker updates at
+   the boundary — the PROJECT-MAP.md row changes and the SPEC.md phase-group ✅ marker are the phase
+   group's closing artifact state, so the PR you open next carries them alongside the code. (A
+   gitignored local project: they update on disk only, never in a commit.)
 5. Suggest opening a PR for the completed phase group:
 
    > "Phase [N: name] is complete. This is a good point to open a PR for this work.

--- a/commands/vine/navigate.md
+++ b/commands/vine/navigate.md
@@ -90,8 +90,10 @@ not a mini-PAUSE.md; handoff state lives in PAUSE.md. Its only job is to mark "a
 session is active on this feature" so installed native hooks can scope their checks to
 active work. It never leaves the machine.
 
-**Consume any pause state.** If the feature directory contains a PAUSE.md, picking the work
-back up consumes it: surface its notes in your starting-point summary, then delete the file.
+**Consume any pause state.** If the feature's mirrored personal path
+(`.vine.local/projects/<domain>/<feature-slug>/PAUSE.md`, resolved per *The two roots* in
+`references/STATE.md`) contains a PAUSE.md, picking the work back up consumes it: surface its
+notes in your starting-point summary, then delete the file.
 A consumed pause must not linger — it would keep suggesting `/vine:resume` for work that has
 already resumed.
 

--- a/commands/vine/pause.md
+++ b/commands/vine/pause.md
@@ -34,9 +34,9 @@ back.
 
 ## Identify the Feature
 
-Scan `.vine/projects/` for feature directories. Filter out resolved projects (directories
-containing a `.resolved` file) and archived projects (under `.vine/projects/.archive/`). If all
-projects are resolved or archived, tell the engineer there's nothing active to pause.
+Scan for feature directories per the Filtering Convention in `references/STATE.md` (both roots;
+resolved and `.archive/` subtrees filtered out). If all projects are resolved or archived, tell the
+engineer there's nothing active to pause.
 
 If a feature path was passed as an argument, use it directly. Otherwise:
 

--- a/commands/vine/pause.md
+++ b/commands/vine/pause.md
@@ -80,7 +80,10 @@ Ask a single question with `freeform: true`:
 
 ## Write PAUSE.md
 
-Write PAUSE.md to the feature directory, matching the template defined in `references/STATE.md`:
+Write PAUSE.md to the feature's **mirrored personal path** —
+`.vine.local/projects/<domain>/<feature-slug>/PAUSE.md` (the shared personal root, resolved per
+*The two roots* in `references/STATE.md`) — matching the template defined there. Pause state is
+personal, so it lives under `.vine.local/` even for a shared `.vine/projects/` feature:
 
 ```markdown
 # Paused: [Feature Name]
@@ -92,7 +95,7 @@ Write PAUSE.md to the feature directory, matching the template defined in `refer
 [Engineer's notes from above, or "No notes captured." if they skipped]
 ```
 
-If a PAUSE.md already exists in the feature directory, overwrite it — only the most recent
+If a PAUSE.md already exists at that path, overwrite it — only the most recent
 pause state matters.
 
 ## Clear the Active-Session Sentinel
@@ -106,7 +109,7 @@ file doesn't exist, skip silently — pausing from a non-navigate phase is norma
 
 ```
 ---
-✅ vine:pause complete → .vine/projects/<domain>/<feature-slug>/PAUSE.md written
+✅ vine:pause complete → .vine.local/projects/<domain>/<feature-slug>/PAUSE.md written
    Feature: [name]
    Phase: [phase]
    Active slice: [slice or N/A]

--- a/commands/vine/resume.md
+++ b/commands/vine/resume.md
@@ -53,7 +53,9 @@ Read whatever exists in the feature directory. Build your understanding in layer
 
 ### Layer 1: PAUSE.md (if present)
 
-Read `.vine/projects/<domain>/<feature-slug>/PAUSE.md`. Extract:
+Read `.vine.local/projects/<domain>/<feature-slug>/PAUSE.md` — the feature's mirrored personal path
+(shared personal root, resolved per *The two roots* in `references/STATE.md`); pause state lives under
+`.vine.local/` even for a shared `.vine/projects/` feature. Extract:
 - **Phase** at time of pause
 - **Active slice** (if navigate was in progress)
 - **Timestamp** — calculate how long ago the pause was

--- a/commands/vine/resume.md
+++ b/commands/vine/resume.md
@@ -36,11 +36,10 @@ to re-read everything yourself.
 
 ## Identify the Feature
 
-Scan `.vine/projects/` for feature directories. Filter out resolved projects (directories
-containing a `.resolved` file) and archived projects (under `.vine/projects/.archive/`). If all
-projects are resolved or archived, tell the engineer there's nothing to resume and suggest
-starting a new cycle with `/vine:verify` — present the command in its own fenced code block
-so it's copy-pastable.
+Scan for feature directories per the Filtering Convention in `references/STATE.md` (both roots;
+resolved and `.archive/` subtrees filtered out). If all projects are resolved or archived, tell the
+engineer there's nothing to resume and suggest starting a new cycle with `/vine:verify` — present
+the command in its own fenced code block so it's copy-pastable.
 
 If a feature path was passed as an argument, use it directly. Otherwise:
 

--- a/commands/vine/status.md
+++ b/commands/vine/status.md
@@ -35,8 +35,9 @@ when deciding which feature to pick up.
 
 ## Identify the Feature
 
-Scan `.vine/projects/` for feature directories. Filter out archived projects (under
-`.vine/projects/.archive/`). Include resolved projects but mark them as such.
+Scan for feature directories per the Filtering Convention in `references/STATE.md` (both roots,
+`.archive/` subtrees filtered). Unlike the other enumerating commands, status **includes** resolved
+projects — mark them as such rather than filtering them out.
 
 If a feature path was passed as an argument, use it directly. Otherwise:
 

--- a/commands/vine/verify.md
+++ b/commands/vine/verify.md
@@ -328,10 +328,11 @@ from the absence of objections; ask for it. This is the gate that closes verify,
 
 Once approved:
 
-1. If the repo tracks artifacts (`git check-ignore -q .vine/projects` exits non-zero), commit
-   CONTEXT.md and PROJECT-MAP.md now — this is their first entry into history (see "Committing
-   Artifacts" in `references/STATE.md`). If the path is gitignored, skip this step silently —
-   personal-scope artifacts never enter a commit.
+1. If this feature directory is tracked (run `git check-ignore -q` against the **specific feature
+   directory** — the per-path test in "Committing Artifacts", `references/STATE.md` — and it exits
+   non-zero), commit CONTEXT.md and PROJECT-MAP.md now — this is their first entry into history. If
+   the feature directory is gitignored (a local project under `.vine.local/projects/`), skip this
+   step silently — personal-scope artifacts never enter a commit.
 2. Persist actionable retro items before printing the completion block. The retro is
    conversation output and doesn't survive `/clear` — anything inquire should act on
    belongs in the relevant CONTEXT.md section (open questions, tribal knowledge,

--- a/references/STATE.md
+++ b/references/STATE.md
@@ -599,6 +599,15 @@ init's archive sweep, and trellis's glob — **scan both roots** and apply the s
 4. If all projects across both roots are resolved/archived, tell the engineer and suggest starting a
    new cycle with `/vine:verify` — present the command in its own fenced code block so it's copy-pastable.
 
+**Resolving the personal root.** The shared tree `.vine/` is checked out in every worktree, so
+`.vine/projects/` is always cwd-relative. The personal tree is gitignored and therefore *not* checked
+out into a linked worktree, so resolve `.vine.local/projects/` at the repository's **primary**
+worktree — `git rev-parse --git-common-dir`, whose parent is the main worktree root where
+`.vine.local/` lives — rather than cwd-relative. Every worktree then enumerates the *same* local-only
+projects instead of silently finding none. A non-git directory falls back to the cwd-relative
+`.vine.local/`. (This is the shared-personal-root anchoring; the `ACTIVE` sentinel resolves
+differently — per-working-tree — and is specified in its own section.)
+
 This two-root scan is stated **once, here**; the scan sites reference this convention rather than
 restating the rule per site (the referential-homes anti-duplication stance). If the engineer needs to
 access a resolved project, they can pass its path explicitly as an argument.

--- a/references/STATE.md
+++ b/references/STATE.md
@@ -13,9 +13,16 @@ This namespacing allows multiple features to be VINEd concurrently without colli
 VINE state lives under two sibling roots in the project root:
 
 - **`.vine/`** — the **shared** tree, tracked by default, travels with the repo: team overlays (`.vine/context/`), shared feature projects (`.vine/projects/`), durable knowledge (`.vine/knowledge/`), and `.vine/README.md`.
-- **`.vine.local/`** — the **personal** tree: a gitignored sibling root that mirrors `.vine/`'s structure on demand (`context/`, `projects/`, optionally `knowledge/`, plus `PROFILE.md` and `ACTIVE`). It holds everything personal to one machine — personal overlays, the engineer profile (`.vine.local/PROFILE.md`), the active-session sentinel (`.vine.local/ACTIVE`), pause state (`.vine.local/projects/<domain>/<feature-slug>/PAUSE.md`), and local-only feature projects. The **whole root is gitignored** — a single `.vine.local/` rule, with no per-file ignore rules inside `.vine/`.
+- **`.vine.local/`** — the **personal** tree: a gitignored sibling root that mirrors `.vine/`'s structure on demand (`context/`, `projects/`, optionally `knowledge/`, plus `PROFILE.md`). It holds everything personal *and shared across this repo's worktrees* — personal overlays, the engineer profile (`.vine.local/PROFILE.md`), pause state (`.vine.local/projects/<domain>/<feature-slug>/PAUSE.md`), and local-only feature projects. The root is gitignored by a single `.vine.local/` rule. (The active-session sentinel `ACTIVE` is the one ephemeral file that does *not* live here — it must be per-working-tree, so it stays at `.vine/ACTIVE` inside the shared tree, gitignored; see its section below.)
 
 The shared/personal split is **location-based**: a file's root marks its scope, not a filename suffix. A repo overlay at `.vine/context/shared.md` has a personal counterpart at `.vine.local/context/shared.md` (the `.local` filename suffix is dropped — the root already signals personal scope). The overlay loader composes personal-over-repo with the policy-class carve-out unchanged (see `.vine/context/shared.md`, "Overlay Precedence"). Per-repo personal state persists across all VINE cycles.
+
+**Resolving the roots (git worktrees and clones).** The shared tree `.vine/` is checked out in every worktree, so it is always cwd-relative. The personal tree is gitignored and therefore *not* checked out into a linked worktree — resolving it cwd-relative would make a worktree session silently see no profile, no personal overlays, no local projects. So the personal root is keyed to the **repository**, not the working directory, and splits by scope:
+
+- **Shared personal root** (profile, personal overlays, local-only projects, pause state) → resolve at the repository's **primary** worktree: `dirname "$(git rev-parse --git-common-dir)"`. Identical from every linked worktree, so one profile / overlay set / set of local projects is seen everywhere. This is where `.vine.local/` literally lives (a visible sibling at the main checkout).
+- **`ACTIVE` sentinel** (per-working-tree) → stays at the cwd-relative `.vine/ACTIVE`. No git resolution needed: `.vine/` is a tracked tree, so every worktree checks out its **own** working copy, and a gitignored `.vine/ACTIVE` written in one worktree exists only in that worktree's filesystem. It is therefore per-tree by construction — installed hooks read `$root/.vine/ACTIVE` and never cross-fire between concurrent worktree sessions — without any `git rev-parse`. It is gitignored, and the gitignore inversion (the track-by-default flip) keeps it ignored with an explicit `.vine/ACTIVE` rule alongside `.vine.local/`.
+
+Only the shared personal root needs git resolution; a non-git directory falls back to the cwd-relative `./.vine.local/`. (`ACTIVE` is always just `.vine/ACTIVE`, git or not.) Rationale: knowledge ADR `2026-06-22-anchor-the-personal-root-at-the-repo-shared-across-worktrees`.
 
 ## State Files
 
@@ -245,7 +252,7 @@ thinking, what to pick up first, anything that won't survive a session break]
 2. **Overwritten** by subsequent `vine:pause` calls — only one pause state exists per feature at a time.
 3. **Consumed** (read, surfaced, then deleted) by whatever picks the work back up. Every deletion trigger:
    - `vine:resume` — after displaying the notes.
-   - `vine:navigate` — at session start, the same moment `.vine.local/ACTIVE` is written; notes are surfaced in the starting-point summary first.
+   - `vine:navigate` — at session start, the same moment `ACTIVE` is written; notes are surfaced in the starting-point summary first.
    - `vine:inquire` — at session start, after reading CONTEXT.md (handles a pause taken after verify); notes are surfaced in the context summary first.
    - `vine:evolve` — at session start, after reading the feature's artifacts; notes are surfaced first.
    - `vine:evolve` when writing `.resolved` — backstop; session-start consumption normally removed PAUSE.md already, so a surviving one is surfaced then deleted like the rest (its notes appeared after evolve began and aren't necessarily stale).
@@ -259,9 +266,9 @@ thinking, what to pick up first, anything that won't survive a session break]
 - **One per feature.** No history of pause states. The most recent pause is the only one that matters.
 - **Consumed-once.** Picking the work back up deletes the file. Notes worth keeping beyond the resume belong in NAVIGATION.md's Remaining Work, not in PAUSE.md.
 
-### .vine.local/ACTIVE (active-session sentinel, written by vine:navigate)
+### ACTIVE (active-session sentinel, written by vine:navigate)
 
-An ephemeral repo-level sentinel marking "a navigate session is active on this feature right now." It lives at `.vine.local/ACTIVE` (repo root, under the gitignored personal tree, not inside a feature directory) and never leaves the machine — so pulled In-Progress journals from teammates can never make installed hooks fire.
+An ephemeral repo-level sentinel marking "a navigate session is active on this feature right now." It lives at `.vine/ACTIVE` (repo root, not inside a feature directory), is gitignored, and never leaves the machine — so pulled In-Progress journals from teammates can never make installed hooks fire. It is **per-working-tree**: `.vine/` is a tracked tree, so every worktree checks out its own working copy, and a gitignored `.vine/ACTIVE` exists only in the worktree that wrote it — two concurrent worktree sessions never cross-fire each other's hooks, with no git-dir resolution. (The gitignore inversion keeps it ignored via an explicit `.vine/ACTIVE` rule.)
 
 ```
 feature: .vine/projects/<domain>/<feature-slug>
@@ -275,7 +282,7 @@ Its consumers are native hook scripts (see `.vine/scripts/`): they test the sent
 
 1. **Written** by `vine:navigate` at session start, the same moment any PAUSE.md is consumed. At a phase group boundary where the engineer continues immediately, navigate updates the `phase:` line instead of rewriting.
 2. **Deleted** at every session end: navigate's completion and pause-between-slices paths, `vine:pause`, and `vine:evolve` at session start (an evolve session means no navigate session is active).
-3. **Stale sentinel escape hatch:** if a session dies without cleanup (crash, closed terminal), hooks may fire against inactive work. The fix is `rm .vine.local/ACTIVE` — hook block messages name this command.
+3. **Stale sentinel escape hatch:** if a session dies without cleanup (crash, closed terminal), hooks may fire against inactive work. The fix is `rm .vine/ACTIVE` — hook block messages name this command.
 
 **Design constraints:**
 
@@ -285,11 +292,11 @@ Its consumers are native hook scripts (see `.vine/scripts/`): they test the sent
 
 ### .vine/scripts/ (native hook scripts)
 
-Shell-script home for VINE's native hook scripts — the enforcement layer behind guarantees that command prose can only request. Scripts are wired into a repo's hook configuration by init's scaffold offer (declinable; declining changes nothing on disk). All scripts are POSIX sh, treat `.vine.local/ACTIVE`'s feature path as an opaque repo-relative string, and **fail open**: no sentinel, missing tooling, or ambiguity exits 0 — enforcement degrades, sessions never break.
+Shell-script home for VINE's native hook scripts — the enforcement layer behind guarantees that command prose can only request. Scripts are wired into a repo's hook configuration by init's scaffold offer (declinable; declining changes nothing on disk). All scripts are POSIX sh, read the `ACTIVE` sentinel at `.vine/ACTIVE` (per-working-tree, no git resolution), treat its feature path as an opaque repo-relative string, and **fail open**: no sentinel, missing tooling, or ambiguity exits 0 — enforcement degrades, sessions never break.
 
 | Script | Hook event | Behavior |
 |--------|------------|----------|
-| `journal-check.sh` | PreToolUse (Bash) | Blocks `git commit` (exit 2) while a navigate session is active and the active feature's NAVIGATION.md is older than the last commit. The block message names the journal and the `rm .vine.local/ACTIVE` escape hatch. |
+| `journal-check.sh` | PreToolUse (Bash) | Blocks `git commit` (exit 2) while a navigate session is active and the active feature's NAVIGATION.md is older than the last commit. The block message names the journal and the `rm .vine/ACTIVE` escape hatch. |
 
 Validation/lint enforcement is deliberately outside the scaffold: when and how to run a project's checks depends on its tooling, so that decision stays with the repo (native hooks in `.claude/settings.json` are available directly). VINE's validation contract is the optional fenced `## Validation` block in `.vine/context/shared.md` (keys `lint`/`typecheck`/`test`/`test-all`/`build`/`extra`, all optional); `vine-verification` reads it and falls back to prose inference when it is absent.
 
@@ -498,7 +505,7 @@ Project *state* follows the same single-home discipline the Knowledge Boundary r
 |-------|-----------------|-----------|
 | The plan — what slices and phase groups exist | `SPEC.md` | durable |
 | Implementation progress — which slices are done, with commits, decisions, learnings | `NAVIGATION.md` | durable |
-| What's active right now | `.vine.local/ACTIVE` | ephemeral |
+| What's active right now | `.vine/ACTIVE` (per-worktree, gitignored) | ephemeral |
 | Handoff notes across a session gap | `PAUSE.md` | ephemeral |
 
 **Derived views** (never authoritative; rebuilt from the sources above):
@@ -599,14 +606,10 @@ init's archive sweep, and trellis's glob — **scan both roots** and apply the s
 4. If all projects across both roots are resolved/archived, tell the engineer and suggest starting a
    new cycle with `/vine:verify` — present the command in its own fenced code block so it's copy-pastable.
 
-**Resolving the personal root.** The shared tree `.vine/` is checked out in every worktree, so
-`.vine/projects/` is always cwd-relative. The personal tree is gitignored and therefore *not* checked
-out into a linked worktree, so resolve `.vine.local/projects/` at the repository's **primary**
-worktree — `git rev-parse --git-common-dir`, whose parent is the main worktree root where
-`.vine.local/` lives — rather than cwd-relative. Every worktree then enumerates the *same* local-only
-projects instead of silently finding none. A non-git directory falls back to the cwd-relative
-`.vine.local/`. (This is the shared-personal-root anchoring; the `ACTIVE` sentinel resolves
-differently — per-working-tree — and is specified in its own section.)
+**Resolving the personal root.** `.vine/projects/` is cwd-relative, but `.vine.local/projects/` must
+be resolved at the shared personal root (`dirname "$(git rev-parse --git-common-dir)"`) so a worktree
+session enumerates the *same* local-only projects instead of silently finding none — see *The two
+roots → Resolving the roots* above for the full rule and the non-git fallback.
 
 This two-root scan is stated **once, here**; the scan sites reference this convention rather than
 restating the rule per site (the referential-homes anti-duplication stance). If the engineer needs to


### PR DESCRIPTION
## What

VINE keeps two trees of state: `.vine/` (shared, committed with the repo) and `.vine.local/` (personal, gitignored). This PR makes the commands actually operate across both:

- Every command that lists feature projects (status, resume, pause, navigate, inquire, evolve, init's archive sweep) and the `trellis` validator now scans **both** trees, via a single "Filtering Convention" stated once in `references/STATE.md` and referenced everywhere else.
- Personal pause-notes (`PAUSE.md`) move from the shared feature dir to the mirrored personal path under `.vine.local/`.
- The "commit this artifact or not?" decision is now made **per project** (shared → commit, personal → skip) instead of by one global check.
- The personal tree is resolved at the repository's main checkout, so a `git worktree` session sees the same profile/overlays/projects instead of silently finding none.

## Why

Refs #52. The previous PR (#122) defined the two-tree model; this makes the rest of the commands honor it. Without it, personal projects and pause state wouldn't be discovered, and worktree sessions silently ran with no profile. Second of three PRs for the team-layer cycle — the `.gitignore` flip (#108) and the docs sweep land in the next one.

One design note worth surfacing: the active-session sentinel (`ACTIVE`) stays at `.vine/ACTIVE` (gitignored) rather than moving into git's private dir as an earlier design record proposed — a tracked dir is already checked out per-worktree, so a gitignored file inside it is per-worktree for free. The decision record is amended in place to explain why.

## How to test

1. `sh .vine/scripts/run-tests.sh` — hook test matrix (24 pass).
2. `sh .vine/scripts/trellis-check.sh` — command structure + cross-reference anchors (green).
3. Skim `references/STATE.md` → "The two roots" and "Filtering Convention" for the contract these commands now reference.

## Checklist

- [x] I've tested this in an actual VINE cycle (built via /vine:navigate; trellis + hook tests green)
- [x] Changes are focused on a single concern (Phase 2: discovery + session plumbing)
- [x] New behavior is documented (the `references/STATE.md` contract + command prose)