### PR TITLE
vine-reviewer: compare against origin/<base> when computing PR diff range

### DIFF
--- a/agents/vine-reviewer.md
+++ b/agents/vine-reviewer.md
@@ -35,7 +35,10 @@ Read in this order; later items will make sense because of earlier ones:
    are addressed to you.
 3. **The commits** — `git log` + `git show` for each commit the journal names. The diff is the
    ground truth; the journal is the actor's account of it. Discrepancies between the two are
-   findings.
+   findings. When computing the PR's change range, fetch and compare against the remote base —
+   `git fetch origin <base> && git log origin/<base>..HEAD` — not the local base ref, which may be
+   stale (especially in a linked worktree, where the base branch is checked out elsewhere); a stale
+   local base makes already-merged work look like part of this PR.
 4. **The touched files in their final state** — read enough of each changed file to judge the change
    in context, not just the diff hunks.
 


### PR DESCRIPTION
## What

The `vine-reviewer` agent recipe now tells the reviewer to fetch and compare against the remote base branch (`origin/<base>`) when computing a PR's diff/commit range, instead of the local base ref.

## Why

A cold reviewer running from a linked git worktree commonly hits a stale local base ref, because the base branch is checked out elsewhere. With a stale local `main`, the change range can include already-merged work, making the diff look larger than it is. Comparing against the freshly-fetched remote base avoids the dead-end.

This surfaced during a review of an earlier PR, where the reviewer had to recover by fetching `origin/main` and recomputing — the recipe now makes that the default orientation step.

## How to test

1. Open `agents/vine-reviewer.md` and confirm orientation step 3 instructs fetching/comparing against `origin/<base>`.
2. Run `sh .vine/scripts/trellis-check.sh` — stays green (11/11, anchors resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)