### PR TITLE
Track .vine/ by default; add a personal .vine.local/ root (#52)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,19 +8,10 @@ Thumbs.db
 *.swp
 *.swo
 
-# VINE workflow artifacts (dogfooding)
-# Track context overlays and resolved projects for contributor context
-# Ignore active work, profile, and ephemeral state
-.vine/*
-!.vine/README.md
-!.vine/context/
-!.vine/knowledge/
-!.vine/projects/
-!.vine/scripts/
-.vine/projects/*/*/PAUSE.md
-.vine/PROFILE.md
-# Personal overlay layer — gitignored by design (absent .local changes nothing)
-.vine/context/*.local.md
+# VINE workflow artifacts (dogfooding) — track by default; ignore only personal + ephemeral state
+.vine.local/
+.vine/ACTIVE
+.vine/.trellis-ok
 
 # Claude Code worktrees
 .claude/worktrees/

--- a/.vine/context/shared.md
+++ b/.vine/context/shared.md
@@ -78,7 +78,7 @@ The command and agent inventory lives in the harness's native skill list, not in
 ## Project Conventions
 
 ### Repository Structure
-See `CLAUDE.md` — repo facts live there (Knowledge Boundary rule, `references/STATE.md`). All `.vine/context/` overlays are tracked in git for contributor onboarding (this repo runs E2-shaped: `.vine/projects/` is tracked too, with PAUSE.md and PROFILE.md excluded).
+See `CLAUDE.md` — repo facts live there (Knowledge Boundary rule, `references/STATE.md`). This repo tracks `.vine/` by default (overlays, knowledge, and feature projects travel with the repo for contributor onboarding); personal and ephemeral state lives in the gitignored personal root `.vine.local/` (profile, personal overlays, pause state, local-only projects), with the `.vine/ACTIVE` session sentinel gitignored in place.
 
 ### Writing Style
 Command authoring conventions live in `CLAUDE.md` (Knowledge Boundary rule: repo facts every contributor session needs).

--- a/.vine/projects/workflow/team-layer/NAVIGATION.md
+++ b/.vine/projects/workflow/team-layer/NAVIGATION.md
@@ -389,7 +389,7 @@ prose (the three coupled parts) before editing.
 
 ### Slice 9: The `.gitignore` flip + init scaffold + Upgrade Mode + repo migration — Complete
 **Started**: 2026-06-22 15:05
-**Commit**: pending
+**Commit**: 9c465dc
 **Gear**: walk-me-through
 **Approach taken**: Four parts. (1) **init Step 6 (shipped template)** flipped from the
 ignore-by-default model (`.vine/*` + `!.vine/README.md`) to track-by-default: the scaffolded
@@ -443,6 +443,65 @@ briefly show `.vine.local/PROFILE.md` untracked until PR 3 merges — cosmetic, 
     nothing personal — the flip's real work is the relocation that precedes it, not the rule swap. In a
     worktree the relocation must target the git-common-dir-anchored primary, not cwd, or the personal
     file is either invisible (pre-move) or wrongly tracked (post-flip).
+
+### Slice 10: Documentation sweep — Complete
+**Started**: 2026-06-22 15:35
+**Commit**: pending
+**Gear**: free-climb
+**Approach taken**: Swept five doc surfaces to the now-real `.vine.local/` track-by-default model.
+(1) **CLAUDE.md** — dropped "PAUSE.md gitignored" from the projects bullet (PAUSE now under
+`.vine.local/`), replaced the `.vine/PROFILE.md` bullet with a `.vine.local/` personal-root bullet,
+and moved the two prose path refs (`Load Engineer Profile` reader, the profile-tracking line) +
+the pause-location line to `.vine.local/`. (2) **shared.md** line 81 — the "E2-shaped … PAUSE.md
+and PROFILE.md excluded" note → "tracks `.vine/` by default; personal/ephemeral state in
+`.vine.local/`". (3) **init.md Step 4 `.vine/README.md` scaffold** — reconciled the split-brain
+flagged in the Slice 8 handoff: dropped the `shared.local.md`/`PROFILE.md` table rows, narrowed the
+ephemeral row to `ACTIVE`, added a personal-root paragraph, and updated the overlay-list item 3 +
+the precedence prose from `shared.local.md` to `.vine.local/context/<name>.md`. (4) **README
+"Piloting"** — reframed from "gitignore all of `.vine/`, commit later" (backwards under
+track-by-default) to a solo→team graduation path: keep-features-local via verify, or whole-`.vine/`
+global-gitignore for full-local piloting, then graduate by committing `.vine/context/` + policy
+markers (points at shared.md's team recommendation). Also fixed the README profile-layer path
+`.vine/PROFILE.md` → `.vine.local/PROFILE.md`. (5) **STATE.md** — fixed the stale "README is the one
+tracked file under `.vine/` (init adds `!.vine/README.md`)" claim (`STATE.md:408`) to track-by-default;
+the contract surfaces (Filtering Convention, Committing Artifacts, ACTIVE guarantee, two roots) were
+already correct from Slices 1/4/5. **Session hygiene**: merged `origin/main` into the branch first
+(engineer chose "continue + get updates from main") — brought in #124 (vine-reviewer diff range) and
+#125 (permission-mode copy alignment); clean auto-merge, no conflicts; the gitignore flip survived.
+**Deviations from spec**: None. AC11's STATE.md surfaces were mostly closed in earlier slices; this
+slice closed the one straggler (the README-orientation-doc description) plus the four other surfaces.
+The State Artifact Addition Checklist applies only loosely — `.vine.local/` is a directory/gitignore
+convention, not a CONTEXT→…→EVOLUTION state artifact — so the pass was verifying the checklist-covered
+surfaces (STATE.md, CLAUDE.md, README, trellis) all reflect it, which they now do.
+**Validation**: pass — `sh .vine/scripts/trellis-check.sh` exit 0 (11/11 commands, 8 cross-ref anchor
+pairs). Final cross-surface grep confirms no stale `shared.local.md`, `.vine/PROFILE.md` (outside the
+migration prose that names it as a move *source*), `.vine/...PAUSE`, or `E2-shaped`/allowlist remnants.
+Two pre-existing allowlisted `.vine/hooks/` legacy warnings (init.md:105-106) are unrelated.
+**Decisions made during implementation**:
+  - Move personal files OUT of the init `.vine/README.md` scaffold table (rather than relabel the
+    rows) — the table is titled "What lives under `.vine/`" and personal state now lives under
+    `.vine.local/`, so a pointer paragraph is more honest than rows for files that aren't there
+    (decided by: claude; confidence: high)
+  - Keep README "Piloting" offering the whole-`.vine/`-global-gitignore escape hatch alongside the
+    per-feature keep-local option — full-local piloting is still a real need under track-by-default
+    (decided by: claude; confidence: high)
+  - Merge (not rebase) origin/main, to preserve the Slice 7/8/9 commit hashes the journal records
+    (decided by: claude; confidence: high)
+**Acceptance criteria**:
+  - [x] AC11 — README "Piloting", CLAUDE.md tracked/gitignored bullets, init's `.vine/README.md`
+    scaffold, and `references/STATE.md` reflect the `.vine.local/` contract + team recommendation
+  - [x] AC12 — `/trellis` passes; no command file references a personal path that has moved
+    (verified by grep across commands/, references/, README.md, CLAUDE.md, .vine/context/)
+**Engineer feedback incorporated**: Chose free-climb for the docs sweep (confident workflow profile);
+chose "continue this session + get updates from main", which drove the pre-sweep merge of origin/main.
+**Learnings**:
+  - Engineer → Claude: Sync from main before the final slice of a multi-PR feature — parallel PRs
+    (#124, #125) had landed, and folding them in now means PR 3 builds on current main rather than
+    surprising the reviewer with a stale base.
+  - Claude → Engineer: A docs sweep after a model change is really a grep-for-the-old-model pass —
+    the stragglers (STATE.md's README description, the README profile path) lived outside the SPEC's
+    named surfaces and only a cross-surface grep caught them. Naming the surfaces in the SPEC gets you
+    80%; the grep gets the rest.
 
 ### Handoff note for Slice 9 (init Upgrade Mode)
 Upgrade Mode should offer to relocate a legacy `.vine/context/*.local.md` → `.vine.local/context/*.md`

--- a/.vine/projects/workflow/team-layer/NAVIGATION.md
+++ b/.vine/projects/workflow/team-layer/NAVIGATION.md
@@ -339,7 +339,7 @@ redirection.
 
 ### Slice 8: evolve local→shared promotion — Complete
 **Started**: 2026-06-22 14:22
-**Commit**: pending
+**Commit**: 8b17ec0
 **Gear**: walk-me-through (continued in this session from Slice 7; previewed the three-part approach
 in prose before editing, edits reviewable at the slice boundary)
 **Approach taken**: Three coupled changes to evolve's wrap-up flow (`commands/vine/evolve.md`).
@@ -386,6 +386,63 @@ prose (the three coupled parts) before editing.
     means the location change propagates through the per-path test for free, so the downstream steps
     stay root-agnostic. The deferred-fix notes from Slices 5/6 paid off: the root-aware `.resolved` and
     archive work was already scoped and waiting in the exact paths this slice opened.
+
+### Slice 9: The `.gitignore` flip + init scaffold + Upgrade Mode + repo migration — Complete
+**Started**: 2026-06-22 15:05
+**Commit**: pending
+**Gear**: walk-me-through
+**Approach taken**: Four parts. (1) **init Step 6 (shipped template)** flipped from the
+ignore-by-default model (`.vine/*` + `!.vine/README.md`) to track-by-default: the scaffolded
+`.gitignore` is now `.vine.local/` + `.vine/ACTIVE` (two lines), tracking the rest of `.vine/`. The
+"What This Does" summary line (`init.md:28`) flipped in lockstep. (2) **init Step 8** gained a new
+`### Track-by-Default Migration` subsection (parallel to Legacy Directory Migration): detects the old
+ignore model, offers via `AskUserQuestion` to relocate personal files into `.vine.local/` *then* flip
+`.gitignore`, where declining is a no-op (#58 rename-fallback). (3) **This repo's `.gitignore`
+flipped** — the deny-then-allowlist block (11 lines, re-admitting context/knowledge/projects/scripts)
+collapsed to three: `.vine.local/`, `.vine/ACTIVE`, `.vine/.trellis-ok` (the last is contributor-only,
+not in the shipped template). (4) **Worked-example migration**: relocated `.vine/PROFILE.md` →
+`.vine.local/PROFILE.md` at the *primary* checkout (where the personal root anchors via git-common-dir),
+removed this worktree's PROFILE symlink stopgap, and verified.
+**Deviations from spec**: Two intent-over-letter resolutions, both pre-flagged (see SPEC Slice 9
+addendum). (1) AC1's "`.vine.local/` is the *only* rule" → the flip also carries `.vine/ACTIVE` (Slice
+5 kept ACTIVE there) and this repo adds contributor-only `.vine/.trellis-ok`; shipped template is two
+lines, this repo's three. (2) The Goal's "relocate ACTIVE wiring" → ACTIVE didn't move, so the real
+relocation was PROFILE, done at the primary checkout because we're in a worktree.
+**Validation**: pass — `sh .vine/scripts/trellis-check.sh` exit 0 (11/11 commands, 8 cross-ref anchor
+pairs; `.vine/.trellis-ok` stamped). AC verification by direct `git check-ignore`/`git status`: 104
+tracked `.vine/` artifacts unchanged; `.vine/ACTIVE`+`.vine/.trellis-ok` ignored; all `.vine.local/*`
+paths ignored; `git status` shows only `.gitignore`, `init.md`, NAVIGATION.md (Slice 8 backfill); no
+untracked-not-ignored `.vine/` residue (PROFILE symlink gone). Two pre-existing allowlisted
+`.vine/hooks/` legacy warnings (init.md:105-106) are unrelated.
+**Decisions made during implementation**:
+  - Shipped init Step 6 template = two lines (`.vine.local/` + `.vine/ACTIVE`); this repo's actual
+    `.gitignore` = three (adds `.vine/.trellis-ok`). The trellis stamp is a contributor-only artifact
+    `create-vine` never ships, so it doesn't belong in the downstream scaffold (decided by: claude;
+    confidence: high)
+  - Run the PROFILE relocation at the *primary* checkout (not this worktree), since the personal root
+    anchors there via `git rev-parse --git-common-dir`; drop the worktree symlink stopgap so commands
+    read the profile from the anchored `.vine.local/PROFILE.md` (decided by: engineer — chose "I do all
+    4 steps" via AskUserQuestion after I surfaced the cross-worktree wrinkle; confidence: high)
+  - Place Track-by-Default Migration as a sibling of Legacy Directory Migration inside Step 8 (both are
+    pre-upgrade structural migrations), not inside Upgrade Mode proper (decided by: claude; confidence: high)
+**Acceptance criteria**:
+  - [x] AC1 — root `.gitignore` is track-by-default; `git check-ignore` reports every `.vine/` artifact
+    tracked and `.vine.local/*` ignored. **Intent over letter**: also carries `.vine/ACTIVE` (+ this
+    repo's contributor-only `.vine/.trellis-ok`), not the literal single line.
+  - [x] AC9 — init Step 6 scaffolds the new gitignore for fresh repos; Step 8 Upgrade Mode offers the
+    opt-in migration (relocate personal files + flip) where declining changes nothing (#58).
+  - [x] AC10 — this repo migrated as the worked example: `.gitignore` flipped, PROFILE relocated,
+    `git status` shows no unintended tracking changes for committed artifacts (104 tracked, unchanged).
+**Engineer feedback incorporated**: Chose walk-me-through (approve-edits) for this highest-risk slice
+despite a confident workflow profile; chose "I do all 4 steps" for the cross-worktree PROFILE move
+after I laid out the primary-checkout caveat (the primary, on `feature/out-of-scope-routing`, will
+briefly show `.vine.local/PROFILE.md` untracked until PR 3 merges — cosmetic, self-resolving).
+**Learnings**:
+  - Engineer → Claude: (none new this slice)
+  - Claude → Engineer: A gitignore *inversion* is only safe once the to-be-newly-tracked tree holds
+    nothing personal — the flip's real work is the relocation that precedes it, not the rule swap. In a
+    worktree the relocation must target the git-common-dir-anchored primary, not cwd, or the personal
+    file is either invisible (pre-move) or wrongly tracked (post-flip).
 
 ### Handoff note for Slice 9 (init Upgrade Mode)
 Upgrade Mode should offer to relocate a legacy `.vine/context/*.local.md` → `.vine.local/context/*.md`

--- a/.vine/projects/workflow/team-layer/NAVIGATION.md
+++ b/.vine/projects/workflow/team-layer/NAVIGATION.md
@@ -446,7 +446,7 @@ briefly show `.vine.local/PROFILE.md` untracked until PR 3 merges — cosmetic, 
 
 ### Slice 10: Documentation sweep — Complete
 **Started**: 2026-06-22 15:35
-**Commit**: pending
+**Commit**: 924cfc8
 **Gear**: free-climb
 **Approach taken**: Swept five doc surfaces to the now-real `.vine.local/` track-by-default model.
 (1) **CLAUDE.md** — dropped "PAUSE.md gitignored" from the projects bullet (PAUSE now under
@@ -477,6 +477,13 @@ surfaces (STATE.md, CLAUDE.md, README, trellis) all reflect it, which they now d
 pairs). Final cross-surface grep confirms no stale `shared.local.md`, `.vine/PROFILE.md` (outside the
 migration prose that names it as a move *source*), `.vine/...PAUSE`, or `E2-shaped`/allowlist remnants.
 Two pre-existing allowlisted `.vine/hooks/` legacy warnings (init.md:105-106) are unrelated.
+**Phase-group verification follow-up**: the `vine-verification` agent caught two ASCII-art stragglers
+the backtick-pattern grep missed — README's `.vine/` directory-tree illustration showed `PROFILE.md`
+under `.vine/` and `PAUSE.md` under `.vine/projects/`, and the State Artifacts table's PROFILE/PAUSE
+rows lacked a location qualifier. Both fixed: the illustration now shows a tracked `.vine/` tree
+(with `ACTIVE` gitignored in place) plus a sibling `.vine.local/` personal-root tree, and the table
+rows note `.vine.local/`. Lesson logged below: a grep safety-net only catches the path format it
+matches.
 **Decisions made during implementation**:
   - Move personal files OUT of the init `.vine/README.md` scaffold table (rather than relabel the
     rows) — the table is titled "What lives under `.vine/`" and personal state now lives under
@@ -509,10 +516,24 @@ Upgrade Mode should offer to relocate a legacy `.vine/context/*.local.md` → `.
 need — the personal-layer convention never shipped (see Slice 2 decision). Declining must change nothing.
 
 ### Remaining Work
-- **Incomplete slices**: Phase 1 (Slices 1-3) complete and committed (3139119, e28a5c8, df64d3b).
-  Phases 2-3 (Slices 4-10) remain — a fresh session each, per the multi-PR plan.
+- **Incomplete slices**: **All 10 slices complete.** Phase 1 (1-3): 3139119, e28a5c8, df64d3b →
+  PR #122. Phase 2 (4-6): 8cfbfcf, 0833865, d80a95e → PR #123. Phase 3 (7-10): 2a07dfb, 8b17ec0,
+  9c465dc, 924cfc8 (+ a merge of origin/main bringing #124/#125) → PR 3 pending.
 - **Blockers encountered**: None.
-- **Handoff context**:
+- **Handoff context for evolve (PR 3 / feature wrap-up)**:
+  - **Open PR 3 for Phase 3 (Slices 7-10)** before evolve's full-feature pass: the visibility
+    prompts (verify shared/local, evolve promotion), the `.gitignore` flip (closes #108), init's
+    Step 6/8 changes, and the docs sweep.
+  - **Deviations to review** (all SPEC-annotated): Slice 9's AC1 intent-over-letter (gitignore is
+    three lines here, two in the shipped template — `.vine/ACTIVE` + contributor-only `.vine/.trellis-ok`
+    beyond `.vine.local/`) and the "relocate ACTIVE wiring → relocate PROFILE" Goal shift; the earlier
+    Slice 4/5/7/8 in-flow corrections.
+  - **Cosmetic, self-resolving**: the primary checkout (on `feature/out-of-scope-routing`) shows
+    `.vine.local/PROFILE.md` untracked until PR 3 merges to main and the new ignore rule reaches it.
+  - **#52 AC reinterpretation** stands (prescribed team-layer dropped as over-engineering; intent met
+    by tracked `shared.md` + policy marker + #57 plugin distribution) — evolve's knowledge ADR should
+    record the cycle's reshape if not already covered by the existing workflow ADRs.
+  - **Earlier-phase notes (historical, for reviewer context):**
   - **Phase-group verification (Phase 1)**: trellis green; AC1/AC2/AC3/AC6/AC7 all met. The
     `vine-verification` agent flagged `evolve.md:64` (`delete .vine/ACTIVE`) as mismatching STATE.md's
     `.vine.local/ACTIVE`. **Not a Phase 1 gap** — deferred to Slice 5. Direct check confirmed the ACTIVE

--- a/.vine/projects/workflow/team-layer/NAVIGATION.md
+++ b/.vine/projects/workflow/team-layer/NAVIGATION.md
@@ -291,7 +291,7 @@ approve-edits continuity from Slice 5 (each edit reviewed as it landed).
 
 ### Slice 7: verify shared-vs-local prompt — Complete
 **Started**: 2026-06-22 14:16
-**Commit**: pending
+**Commit**: 2a07dfb
 **Gear**: free-climb
 **Approach taken**: Added a **Shared or local?** decision to verify's project-creation flow
 (`commands/vine/verify.md`, inside "### 6. Write CONTEXT.md", right after the domain/slug
@@ -336,6 +336,56 @@ redirection.
     adjacent gitignore guidance — the old first-cycle note was the pre-flip model and would have
     shipped as a self-contradiction next to the new shared/local choice. Same pattern as the
     Slice 4/5 in-flow corrections: getting the visible change right pulls in the coupled stale prose.
+
+### Slice 8: evolve local→shared promotion — Complete
+**Started**: 2026-06-22 14:22
+**Commit**: pending
+**Gear**: walk-me-through (continued in this session from Slice 7; previewed the three-part approach
+in prose before editing, edits reviewable at the slice boundary)
+**Approach taken**: Three coupled changes to evolve's wrap-up flow (`commands/vine/evolve.md`).
+(1) **Promotion offer** — added a `### Promote a Local Project to Shared?` section between the Phase
+Completion block and Mark as Resolved. It fires only for a local project (detected via the per-path
+`git check-ignore` test) and offers, via AskUserQuestion, to move the directory tree from
+`.vine.local/projects/` to `.vine/projects/` (default: promote). The source is gitignored/untracked,
+so the move is a plain `mv` (not `git mv`); the existing *Commit Evolve Changes* step then stages the
+artifacts at their now-tracked path. Placement-before-resolve is deliberate: after the move the
+per-path test reads the project as tracked, so resolve/archive/commit operate on the shared path with
+no special-casing. (2) **`.resolved` marker root-aware** — writes to `<root>/projects/<domain>/<feature-slug>/.resolved`
+(`.vine/` shared, `.vine.local/` if kept local), not the hardcoded `.vine/projects/`. (3) **Archive
+destination root-aware** — archives within the project's *own* root's `.archive/`
+(`.vine/projects/.archive/` shared, `.vine.local/projects/.archive/` local), matching init.md's
+root-aware sweep from Slice 4; the Commit step's post-archive path reference updated to match.
+**Deviations from spec**: Parts (2) and (3) go beyond the SPEC Slice 8 goal's literal "promotion"
+wording, but were explicitly deferred to "Slice 8 territory" in the Slice 5 and Slice 6 journal
+entries — planned scope, not creep. Recorded in the SPEC Slice 8 addendum.
+**Validation**: pass — `sh .vine/scripts/trellis-check.sh` exit 0 (11/11 commands, 8 cross-ref anchor
+pairs; `.vine/.trellis-ok` stamped). Grep confirms the only remaining `.vine/projects/.archive/`
+mention is the prose example illustrating root-awareness, not a hardcoded path. The two pre-existing
+allowlisted `.vine/hooks/` legacy warnings (init.md:104-105) are unrelated. AC8 (evolve half) confirmed
+by inspection: evolve detects a local project, offers promotion, moves the tree to `.vine/projects/`,
+and the commit step stages it as shared.
+**Decisions made during implementation**:
+  - Place the promotion offer *before* Mark as Resolved (not after), so a promotion makes the
+    subsequent resolve/archive/commit see a tracked project automatically — avoids re-deriving the
+    root mid-wrap-up (decided by: claude; confidence: high)
+  - Plain `mv`, not `git mv`, for the promotion: the source is gitignored (untracked), so `git mv`
+    would fail; the existing per-path-aware commit step stages the artifacts at the new tracked path
+    (decided by: claude; confidence: high)
+  - Absorb the deferred root-aware `.resolved` + archive fixes here rather than leave them — Slices
+    5/6 named Slice 8 as their home, and they're in the same wrap-up paths the promotion touches
+    (decided by: claude; confidence: high)
+**Acceptance criteria**:
+  - [x] AC8 (evolve half) — evolve detects a local project and offers local→shared promotion (move
+    the directory tree), then commits as usual
+**Engineer feedback incorporated**: Engineer chose "continue in this session" after Slice 7; I
+suggested flipping back to approve-edits for this slice's move/commit logic. Approach previewed in
+prose (the three coupled parts) before editing.
+**Learnings**:
+  - Engineer → Claude: (none new this slice)
+  - Claude → Engineer: Ordering a lifecycle step matters — putting promotion *before* resolve/archive
+    means the location change propagates through the per-path test for free, so the downstream steps
+    stay root-agnostic. The deferred-fix notes from Slices 5/6 paid off: the root-aware `.resolved` and
+    archive work was already scoped and waiting in the exact paths this slice opened.
 
 ### Handoff note for Slice 9 (init Upgrade Mode)
 Upgrade Mode should offer to relocate a legacy `.vine/context/*.local.md` → `.vine.local/context/*.md`

--- a/.vine/projects/workflow/team-layer/NAVIGATION.md
+++ b/.vine/projects/workflow/team-layer/NAVIGATION.md
@@ -289,6 +289,54 @@ approve-edits continuity from Slice 5 (each edit reviewed as it landed).
     Slice 6 was a pure reference-the-rule pass — the upfront referential-homes investment paid off as a
     mechanical, low-risk close to Phase 2.
 
+### Slice 7: verify shared-vs-local prompt — Complete
+**Started**: 2026-06-22 14:16
+**Commit**: pending
+**Gear**: free-climb
+**Approach taken**: Added a **Shared or local?** decision to verify's project-creation flow
+(`commands/vine/verify.md`, inside "### 6. Write CONTEXT.md", right after the domain/slug
+confirmation). An `AskUserQuestion` defaults to **shared** ("Shared — commit with the repo
+(Recommended)" → `.vine/projects/<domain>/<feature-slug>/`) and offers "Keep this local" →
+`.vine.local/projects/<domain>/<feature-slug>/`. Used a bold lead-in (`**Shared or local?**`)
+rather than a `###` heading so it stays within step 6's prose instead of reading as a new
+top-level step. Updated the "Save this to…" intro (was hardcoded `.vine/projects/`) to the
+root-neutral `<root>/projects/<domain>/<feature-slug>/` pattern, noting `<root>` is `.vine/`
+(default) or `.vine.local/`. The prompt text references *The two roots* for personal-root
+resolution and points at the per-path commit test (Sign-Off Gate) so the routing reads as
+automatic downstream.
+**Deviations from spec**: One bounded addition (engineer-approved via AskUserQuestion, recorded
+in SPEC Slice 7 addendum): replaced verify.md's stale first-cycle note (old lines 262-265,
+"suggest adding `.vine/` to `.gitignore` … `git add -f .vine/`") — the pre-flip model, directly
+contradicted by the shared/local choice in the same flow and in no other slice's file list.
+**Validation**: pass — `sh .vine/scripts/trellis-check.sh` exit 0 (11/11 commands, 8 cross-ref
+anchor pairs; `.vine/.trellis-ok` stamped). Grep confirms no stale gitignore note remains. The two
+pre-existing allowlisted `.vine/hooks/` legacy warnings (init.md:104-105) are unrelated. AC8
+(verify half) confirmed by inspection: default routes to `.vine/projects/`, opt-out to
+`.vine.local/projects/`, single AskUserQuestion per Interaction Constraints.
+**Decisions made during implementation**:
+  - Use a bold lead-in (`**Shared or local?**`) instead of a `###` heading, so the prompt sits in
+    step 6's prose and doesn't renumber/disrupt the numbered-step flow trellis cross-references
+    (decided by: claude; confidence: high)
+  - Fix the stale `.vine/`-to-gitignore note here rather than defer to Slice 10 — it's coupled to
+    the visibility model and in no other slice's file list, so deferring risks dropping it (decided
+    by: engineer — chose "Fix it here" via AskUserQuestion; confidence: high)
+  - Leave the PROJECT-MAP `## Feature:` and completion-block path placeholders showing the shared
+    `.vine/projects/` default rather than churning every placeholder to `<root>/` — the agent fills
+    the real path it just chose at runtime, so a local project gets the correct path without the
+    extra token noise (decided by: claude; confidence: medium)
+**Acceptance criteria**:
+  - [x] AC8 (verify half) — verify defaults new projects to shared and offers a "keep local" option
+    that creates the project under `.vine.local/projects/`
+**Engineer feedback incorporated**: Gear (free climb) and the gitignore-note disposition were both
+presented before coding via AskUserQuestion; engineer chose free climb + fix-here. No mid-slice
+redirection.
+**Learnings**:
+  - Engineer → Claude: (none new this slice)
+  - Claude → Engineer: A "prompt" slice in the project-creation flow can't cleanly ignore the
+    adjacent gitignore guidance — the old first-cycle note was the pre-flip model and would have
+    shipped as a self-contradiction next to the new shared/local choice. Same pattern as the
+    Slice 4/5 in-flow corrections: getting the visible change right pulls in the coupled stale prose.
+
 ### Handoff note for Slice 9 (init Upgrade Mode)
 Upgrade Mode should offer to relocate a legacy `.vine/context/*.local.md` → `.vine.local/context/*.md`
 (suffix dropped) for repos tracking `main`. This is a courtesy migration, not a shipped-version compat

--- a/.vine/projects/workflow/team-layer/PROJECT-MAP.md
+++ b/.vine/projects/workflow/team-layer/PROJECT-MAP.md
@@ -17,4 +17,4 @@
 |-------|--------|--------|----|
 | Phase 1: Composition Model | 1-3 | ✅ Complete | [#122](https://github.com/moduloMoments/VINE/pull/122) |
 | Phase 2: Discovery & Session Plumbing | 4-6 | ✅ Complete | [#123](https://github.com/moduloMoments/VINE/pull/123) |
-| Phase 3: Visibility, the Flip & Docs | 7-10 | ⬜ Pending | — |
+| Phase 3: Visibility, the Flip & Docs | 7-10 | 🚧 Active | — |

--- a/.vine/projects/workflow/team-layer/PROJECT-MAP.md
+++ b/.vine/projects/workflow/team-layer/PROJECT-MAP.md
@@ -8,7 +8,7 @@
 |-------|--------|---------|
 | verify | ✅ | 2026-06-18 |
 | inquire | ✅ | 2026-06-18 |
-| navigate | 🚧 | 2026-06-22 |
+| navigate | ✅ | 2026-06-22 |
 | evolve | ⬜ | — |
 
 ### Milestones
@@ -17,4 +17,4 @@
 |-------|--------|--------|----|
 | Phase 1: Composition Model | 1-3 | ✅ Complete | [#122](https://github.com/moduloMoments/VINE/pull/122) |
 | Phase 2: Discovery & Session Plumbing | 4-6 | ✅ Complete | [#123](https://github.com/moduloMoments/VINE/pull/123) |
-| Phase 3: Visibility, the Flip & Docs | 7-10 | 🚧 Active | — |
+| Phase 3: Visibility, the Flip & Docs | 7-10 | ✅ Complete | — |

--- a/.vine/projects/workflow/team-layer/PROJECT-MAP.md
+++ b/.vine/projects/workflow/team-layer/PROJECT-MAP.md
@@ -17,4 +17,4 @@
 |-------|--------|--------|----|
 | Phase 1: Composition Model | 1-3 | ✅ Complete | [#122](https://github.com/moduloMoments/VINE/pull/122) |
 | Phase 2: Discovery & Session Plumbing | 4-6 | ✅ Complete | [#123](https://github.com/moduloMoments/VINE/pull/123) |
-| Phase 3: Visibility, the Flip & Docs | 7-10 | ✅ Complete | — |
+| Phase 3: Visibility, the Flip & Docs | 7-10 | ✅ Complete | [#126](https://github.com/moduloMoments/VINE/pull/126) |

--- a/.vine/projects/workflow/team-layer/SPEC.md
+++ b/.vine/projects/workflow/team-layer/SPEC.md
@@ -280,6 +280,21 @@ repo as the worked example (relocate ACTIVE wiring; flip `.gitignore`); verify w
 **Acceptance criteria**: AC1, AC9, AC10.
 **Complexity signal**: High — the riskiest change; isolated to its own PR by design.
 
+> **Addendum (implemented 2026-06-22):** two intent-over-letter resolutions, both flagged in
+> earlier slices. (1) **AC1 is not literally one line.** The flipped `.gitignore` is track-by-default
+> but carries `.vine/ACTIVE` alongside `.vine.local/` (ACTIVE stayed at `.vine/ACTIVE` per the Slice 5
+> decision), plus this repo adds the contributor-only `.vine/.trellis-ok` (the trellis-gate stamp,
+> which `create-vine` never ships). So the *shipped* init Step 6 template is two lines
+> (`.vine.local/` + `.vine/ACTIVE`); this repo's actual `.gitignore` is three. AC1's intent
+> (track-by-default, personal root ignored, `git check-ignore` clean across both roots) is met.
+> (2) **The Goal's "relocate ACTIVE wiring" became "relocate PROFILE."** ACTIVE didn't move, so the
+> worked-example migration's real personal-file relocation was `.vine/PROFILE.md` →
+> `.vine.local/PROFILE.md`. Because we ran this in a worktree, the canonical move happened at the
+> primary checkout (where the personal root anchors via `git rev-parse --git-common-dir`) and the
+> worktree's PROFILE symlink stopgap was removed; commands now read the profile from the anchored
+> personal root. `git status` post-flip shows only `.gitignore` + `init.md` changed and all 104
+> tracked `.vine/` artifacts still tracked (AC10).
+
 ### Slice 10: Documentation sweep
 **Goal**: README "Piloting" → solo→team graduation path + repo-level team-overlay recommendation;
 CLAUDE.md tracked/gitignored bullets; init's `.vine/README.md` scaffold table + the forward-looking

--- a/.vine/projects/workflow/team-layer/SPEC.md
+++ b/.vine/projects/workflow/team-layer/SPEC.md
@@ -230,7 +230,7 @@ directory, so shared projects commit and local ones skip.
 **Acceptance criteria**: AC7.
 **Complexity signal**: Low.
 
-## Phase 3: Visibility, the Flip & Docs (Slices 7-10) ⬜
+## Phase 3: Visibility, the Flip & Docs (Slices 7-10) ✅
 Summary: Add the user-facing shared/local choice, perform the `.gitignore` inversion and migrate
 this repo, and update all documentation. The flip lands last, after everything reads the new
 locations.

--- a/.vine/projects/workflow/team-layer/SPEC.md
+++ b/.vine/projects/workflow/team-layer/SPEC.md
@@ -245,6 +245,13 @@ Constraints.
 **Acceptance criteria**: AC8 (verify half).
 **Complexity signal**: Low.
 
+> **Addendum (implemented 2026-06-22):** beyond the literal "prompt" scope, Slice 7 also replaced
+> verify.md's stale first-cycle note (old lines 262-265, *"suggest adding `.vine/` to `.gitignore`
+> … `git add -f .vine/`"*) — the pre-flip model, directly contradicted by the shared/local choice
+> added in the same creation flow. It's in no other slice's file list, so leaving it would ship a
+> self-contradiction. Replaced with the **Shared or local?** model (tracked `.vine/` default,
+> gitignored `.vine.local/` opt-out). Engineer-approved as a bounded in-flow cleanup.
+
 ### Slice 8: evolve local→shared promotion
 **Goal**: At wrap-up, evolve detects a local project and offers to promote it to shared (move the
 directory tree from `.vine.local/projects/` to `.vine/projects/`), then commits as usual.

--- a/.vine/projects/workflow/team-layer/SPEC.md
+++ b/.vine/projects/workflow/team-layer/SPEC.md
@@ -260,6 +260,15 @@ directory tree from `.vine.local/projects/` to `.vine/projects/`), then commits 
 **Acceptance criteria**: AC8 (evolve half).
 **Complexity signal**: Low-Medium — directory move + commit interaction.
 
+> **Addendum (implemented 2026-06-22):** beyond the literal "promotion" goal, Slice 8 also made
+> evolve's `.resolved` marker write and its archive destination **root-aware** — the project resolves/
+> archives within its *own* root (`.vine/projects/.archive/` shared, `.vine.local/projects/.archive/`
+> local), matching init.md's root-aware archive sweep from Slice 4. Both were explicitly deferred to
+> "Slice 8 (evolve local→shared) territory" in the Slice 5 and Slice 6 journal entries, so they're
+> planned scope, not creep. Placement: the promotion offer sits between the completion block and Mark
+> as Resolved, so a promotion makes the subsequent resolve/archive/commit operate on the new shared
+> path with no special-casing.
+
 ### Slice 9: The `.gitignore` flip + init scaffold + Upgrade Mode + repo migration
 **Goal**: Replace the root `.gitignore` deny-allowlist with `.vine.local/` (single rule). Update
 init Step 6 (gitignore template) and Step 8 Upgrade Mode to offer existing repos an opt-in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,16 +15,16 @@ VINE is a pure-markdown AI-assisted development framework. There is no build ste
 - `ROADMAP.md` — Canonical cycle structure; the GitHub milestone is issue-level truth
 - `.github/` — PR template, issue templates (bug, friction, idea)
 - `.vine/context/` — Contributor context overlays (tracked)
-- `.vine/projects/<domain>/<feature-slug>/` — Per-feature VINE artifacts (tracked; PAUSE.md gitignored)
+- `.vine/projects/<domain>/<feature-slug>/` — Per-feature VINE artifacts (tracked)
 - `.vine/knowledge/<domain>/` — Committed durable-decision ADR records (tracked); independent of the project lifecycle, never moved by archival
-- `.vine/PROFILE.md` — Engineer profile (gitignored)
+- `.vine.local/` — Gitignored personal root mirroring `.vine/`: engineer profile (`PROFILE.md`), personal overlays (`context/`), pause state, and local-only feature projects. The `.vine/ACTIVE` session sentinel stays gitignored in place.
 
 ## Command Authoring Conventions
 
 - YAML frontmatter on every command: `name`, `description`, `argument-hint`, `allowed-tools`
 - Valid tool names for `allowed-tools`: Read, Glob, Grep, Write, Edit, Bash, Agent, WebFetch, AskUserQuestion, TaskCreate, TaskUpdate, TaskList (the native task tools are used "when available" by navigate/resume for the live progress view; trellis validates the set by consensus — the union across all commands)
 - Every command (except help) starts with a "Load Context Overlays" section (reads `.vine/context/shared.md` + `.vine/context/<phase>.md`, with a legacy `.vine/hooks/` fallback through 0.4.x)
-- Every command (except init and help) follows overlays with a "Load Engineer Profile" section (reads `.vine/PROFILE.md`). Init creates overlays/profile rather than loading them. Help is a pure reference command that doesn't need project context.
+- Every command (except init and help) follows overlays with a "Load Engineer Profile" section (reads `.vine.local/PROFILE.md`). Init creates overlays/profile rather than loading them. Help is a pure reference command that doesn't need project context.
 - Load Context Overlays must appear before Load Engineer Profile — this ordering is enforced by `/trellis`
 - Commands are written in second-person instructional markdown ("Scan the project for...", "Present a summary...")
 - Sections use `##` headers for major steps, `###` for substeps; anti-patterns and constraints are called out explicitly
@@ -45,11 +45,11 @@ All live in `.vine/projects/<domain>/<feature-slug>/`. Formats are defined in `r
 
 `vine:verify` also creates `PROJECT-MAP.md` as a progress tracker. For multi-PR features, `vine:inquire` adds a Milestones table mapping phase groups to PRs.
 
-`vine:pause` writes an ephemeral `PAUSE.md` to the feature directory. `vine:resume` reads it (plus existing artifacts) to reconstruct session state. PAUSE.md is consumed-once: whatever picks the work back up deletes it (resume after displaying the notes, navigate, inquire, or evolve at session start), with evolve's `.resolved` write as the backstop. `vine:navigate` also maintains `.vine/ACTIVE`, a gitignored active-session sentinel that installed hooks use to scope their checks — full lifecycle in `references/STATE.md`.
+`vine:pause` writes an ephemeral `PAUSE.md` to the feature's mirrored path under `.vine.local/projects/`. `vine:resume` reads it (plus existing artifacts) to reconstruct session state. PAUSE.md is consumed-once: whatever picks the work back up deletes it (resume after displaying the notes, navigate, inquire, or evolve at session start), with evolve's `.resolved` write as the backstop. `vine:navigate` also maintains `.vine/ACTIVE`, a gitignored active-session sentinel that installed hooks use to scope their checks — full lifecycle in `references/STATE.md`.
 
 ## Engineer Profile
 
-`.vine/PROFILE.md` tracks per-domain expertise (confident, familiar, learning, new). Commands use a one-sentence depth hint to adjust explanation depth:
+`.vine.local/PROFILE.md` tracks per-domain expertise (confident, familiar, learning, new). Commands use a one-sentence depth hint to adjust explanation depth:
 
 > "The engineer's profile indicates they are [level] with the [domain] domain. Adjust your explanation depth accordingly — be concise where they're confident, explain the why behind decisions where they're learning or new."
 

--- a/README.md
+++ b/README.md
@@ -157,17 +157,17 @@ cp -r commands/vine .claude/commands/vine
 
 ### Piloting in an existing project (e.g., at work)
 
-VINE creates a `.vine/` directory for feature artifacts and context overlays. If you're trying VINE in a repo you don't want to modify tracked files in, add `.vine/` to your global gitignore so it stays local:
+VINE creates a `.vine/` directory for context overlays and feature artifacts, and tracks it by default — the artifacts are meant to travel with the repo (work-in-public). Personal and ephemeral state stays out of git in the sibling `.vine.local/` root (your profile, personal overlays, pause state). Two ways to pilot before committing to the shared tree:
+
+- **Keep individual features local.** At project creation, `vine:verify` offers a "keep local" option that routes the feature into the gitignored `.vine.local/projects/` instead of the tracked tree.
+- **Keep everything local.** To try VINE in a repo without adding any tracked files, add `.vine/` to your global gitignore:
 
 ```bash
-# Create a global gitignore if you don't have one
 git config --global core.excludesFile ~/.gitignore_global
-
-# Add .vine/ to it
 echo '.vine/' >> ~/.gitignore_global
 ```
 
-This keeps your `.vine/` artifacts out of version control across all repos. When your team is ready to adopt VINE together, you can remove it from the global gitignore and commit `.vine/context/` to the repo instead.
+**Graduating to a team.** When your team adopts VINE together, commit the overlays under `.vine/context/` you want shared and mark team-enforced sections `<!-- class: policy -->` so a personal overlay can't weaken them — see the team-overlay recommendation in `.vine/context/shared.md`. Packaged cross-repo distribution of overlays is a future concern.
 
 ### Optional: GitHub CLI
 
@@ -409,7 +409,7 @@ With AI assistance, engineers at every level are moving into unfamiliar domains 
 
 VINE tracks your growth through a layered profile model:
 
-**VINE layer** (`.vine/PROFILE.md`) — Tracks which domains of this codebase you're comfortable with, based on actual VINE cycles. Four levels: **confident**, **familiar**, **learning**, **new**. Commands use this to calibrate the partnership — your expertise level informs the default engagement style and how much Claude narrates, but you always choose per-slice how closely to work together.
+**VINE layer** (`.vine.local/PROFILE.md`) — Tracks which domains of this codebase you're comfortable with, based on actual VINE cycles. Four levels: **confident**, **familiar**, **learning**, **new**. Commands use this to calibrate the partnership — your expertise level informs the default engagement style and how much Claude narrates, but you always choose per-slice how closely to work together.
 
 **Claude layer** (memory + CLAUDE.md) — General preferences, interaction style, learning patterns. Suggested by `vine:evolve` after each cycle.
 

--- a/README.md
+++ b/README.md
@@ -203,8 +203,7 @@ commands, and conventions without forking the commands themselves. (Pre-0.4 inst
 migration.)
 
 ```
-.vine/
-├── PROFILE.md                     # Engineer profile (per-repo, built over time)
+.vine/                             # Tracked — travels with the repo
 ├── context/
 │   ├── shared.md                  # Loaded by ALL phases
 │   ├── verify.md                  # verify-specific extensions
@@ -215,22 +214,31 @@ migration.)
 ├── knowledge/                     # Durable decisions & gotchas (committed, append-only)
 │   └── workflow/
 │       └── 2026-06-15-cut-the-derived-map-cache.md
+├── projects/
+│   ├── payments/
+│   │   ├── webhook-support/       # Feature 1 (complete)
+│   │   │   ├── CONTEXT.md
+│   │   │   ├── SPEC.md
+│   │   │   ├── NAVIGATION.md
+│   │   │   ├── EVOLUTION.md
+│   │   │   └── PROJECT-MAP.md     # Progress tracker
+│   │   └── retry-logic/           # Feature 2 (in progress)
+│   │       ├── CONTEXT.md
+│   │       ├── SPEC.md
+│   │       └── PROJECT-MAP.md     # Progress + milestones (multi-PR)
+│   └── auth/
+│       └── sso-migration/         # Feature 3 (in progress)
+│           └── CONTEXT.md
+└── ACTIVE                         # Active-session sentinel (gitignored, per-worktree)
+
+.vine.local/                       # Personal root — gitignored, mirrors .vine/
+├── PROFILE.md                     # Engineer profile (per-repo, built over time)
+├── context/
+│   └── shared.md                  # Your personal overlay (optional; overrides preference sections)
 └── projects/
-    ├── payments/
-    │   ├── webhook-support/       # Feature 1 (complete)
-    │   │   ├── CONTEXT.md
-    │   │   ├── SPEC.md
-    │   │   ├── NAVIGATION.md
-    │   │   ├── EVOLUTION.md
-    │   │   └── PROJECT-MAP.md     # Progress tracker
-    │   └── retry-logic/           # Feature 2 (in progress)
-    │       ├── CONTEXT.md
-    │       ├── SPEC.md
-    │       ├── PROJECT-MAP.md     # Progress + milestones (multi-PR)
-    │       └── PAUSE.md           # Session state (ephemeral)
-    └── auth/
-        └── sso-migration/         # Feature 3 (in progress)
-            └── CONTEXT.md
+    └── payments/
+        └── retry-logic/
+            └── PAUSE.md           # Session state (ephemeral, mirrors the feature's path)
 ```
 
 ### shared.md
@@ -319,8 +327,8 @@ when deciding how much to trust a long or lightly-attended session.
 | `NAVIGATION.md` | navigate | Implementation journal, commit-per-slice log |
 | `EVOLUTION.md` | evolve | Verification results, triple evolution report |
 | `PROJECT-MAP.md` | verify (created), all phases (updated) | VINE progress tracker, multi-PR milestone status |
-| `PAUSE.md` | pause | Session state, phase, active slice, engineer notes (ephemeral) |
-| `PROFILE.md` | all phases | Engineer's domain expertise and growth log (per-repo) |
+| `PAUSE.md` | pause | Session state, phase, active slice, engineer notes (ephemeral; in `.vine.local/`) |
+| `PROFILE.md` | all phases | Engineer's domain expertise and growth log (per-repo; in `.vine.local/`) |
 
 These files are human-readable, git-friendly, and designed to survive session boundaries. See the full [State Reference](references/STATE.md) for detailed artifact formats and the chaining protocol.
 

--- a/commands/vine/evolve.md
+++ b/commands/vine/evolve.md
@@ -507,6 +507,38 @@ Update PROJECT-MAP.md (if it exists) — set the evolve row to ✅ with today's 
 ---
 ```
 
+### Promote a Local Project to Shared?
+
+This step runs **only for a local project** — one living under `.vine.local/projects/`. Detect it
+with the per-path `git check-ignore` test from *Committing Artifacts* in `references/STATE.md`: a
+local project's feature directory reads as ignored. For a shared project (`.vine/projects/`), skip
+this step silently.
+
+A finished local project is the natural moment to decide whether the work graduates to shared
+visibility. Offer the promotion with `AskUserQuestion`:
+
+> "This project has been local to your machine. Now that the cycle's wrapping up, want to promote it
+> to shared so its artifacts commit with the repo?"
+
+Options (mutually exclusive):
+1. "Promote to shared (Recommended)" — "Move the project to `.vine/projects/` so it commits with the repo"
+2. "Keep local" — "Leave it under `.vine.local/projects/`; it stays on this machine"
+
+If the engineer promotes, move the directory tree from the personal root to the shared root. The
+source is gitignored (untracked), so this is a plain `mv`, not `git mv`; the *Commit Evolve Changes*
+step then stages the artifacts at their new tracked path. Resolve `.vine.local/` at the shared
+personal root (the repo's primary worktree), per *The two roots* in `references/STATE.md`:
+
+```
+mkdir -p .vine/projects/<domain>
+mv "<personal-root>/.vine.local/projects/<domain>/<feature-slug>" .vine/projects/<domain>/<feature-slug>
+```
+
+After the move the project is shared: the per-path test now reads it as tracked, so the resolve
+marker, any archive, and the evolve commit below all operate on the `.vine/projects/` path
+automatically. Declining changes nothing — the project stays local and the steps below use its
+`.vine.local/projects/` path.
+
 ### Mark as Resolved
 
 After presenting the completion block, offer to mark the project as resolved using
@@ -519,8 +551,10 @@ Options (mutually exclusive):
 1. "Mark resolved (Recommended)" — "Add .resolved marker to this project directory"
 2. "Keep active" — "Leave the project in active state for now"
 
-If the engineer chooses to resolve, write an empty `.resolved` file to
-`.vine/projects/<domain>/<feature-slug>/.resolved`. Then consume any
+If the engineer chooses to resolve, write an empty `.resolved` file to the project's directory —
+`<root>/projects/<domain>/<feature-slug>/.resolved`, where `<root>` is `.vine/` for a shared project
+or `.vine.local/` for one kept local (the promotion step above may have just made it shared). Then
+consume any
 `.vine.local/projects/<domain>/<feature-slug>/PAUSE.md` (the mirrored personal path) that still
 exists — the backstop delete. Evolve's
 session-start consumption normally removed it already, so a PAUSE.md surviving to here appeared
@@ -529,21 +563,24 @@ then delete the file. Never delete it silently — the same surface-then-delete 
 consumption triggers follow (PAUSE.md lifecycle in `references/STATE.md`).
 
 **Offer to archive — move resolved work out of the way.** Only when the engineer just resolved
-the project, offer to archive it — move it to `.vine/projects/.archive/<domain>/<feature-slug>/`, which
+the project, offer to archive it — move it under its own root's `.archive/`
+(`<root>/projects/.archive/<domain>/<feature-slug>/`, root-aware so a shared project archives within
+`.vine/projects/.archive/` and a project kept local within `.vine.local/projects/.archive/`), which
 preserves the artifacts but gets completed work fully out of the way (lifecycle in `references/STATE.md`,
 "Project Lifecycle"). An active project is never archived. Use `AskUserQuestion`:
 
 Options (mutually exclusive):
-1. "Archive now (Recommended)" — "Move the project under `.vine/projects/.archive/`"
+1. "Archive now (Recommended)" — "Move the project under its root's `.archive/`"
 2. "Keep in place" — "Leave it resolved-but-unarchived; archive later by hand"
 
-If the engineer archives, move the project directory — `git mv` when this feature directory is
-tracked (the per-path `git check-ignore` test — see *Committing Artifacts* in `references/STATE.md`)
-so history follows, plain `mv` when it's gitignored (a local project):
+If the engineer archives, move the project directory within its own root — `git mv` when this feature
+directory is tracked (the per-path `git check-ignore` test — see *Committing Artifacts* in
+`references/STATE.md`) so history follows, plain `mv` when it's gitignored (a project kept local).
+With `<root>` the project's root (`.vine/` shared, `.vine.local/` local):
 
 ```
-mkdir -p .vine/projects/.archive/<domain>
-git mv .vine/projects/<domain>/<feature-slug> .vine/projects/.archive/<domain>/<feature-slug>
+mkdir -p <root>/projects/.archive/<domain>
+git mv <root>/projects/<domain>/<feature-slug> <root>/projects/.archive/<domain>/<feature-slug>
 ```
 
 The move carries the artifacts only: PAUSE.md is already gone (consumed-once, deleted at resolve above),
@@ -568,8 +605,8 @@ under *Committing Artifacts*):
   if the repo tracks it.
 
 Never force-add a gitignored artifact. If the project was just archived, its artifacts now live
-under `.vine/projects/.archive/<domain>/<feature-slug>/` — `git mv` already staged the rename, so
-stage any post-move edits at that path. Stage the applicable files and commit with a message like:
+under its root's `.archive/` (`<root>/projects/.archive/<domain>/<feature-slug>/`) — for a tracked
+project `git mv` already staged the rename, so stage any post-move edits at that path. Stage the applicable files and commit with a message like:
 
 ```
 evolve: [feature name] — evolution report and cycle artifacts

--- a/commands/vine/init.md
+++ b/commands/vine/init.md
@@ -25,7 +25,8 @@ team patterns, then scaffolding `.vine/context/` with project-specific templates
 3. Generates `.vine/context/shared.md` and per-phase overlay files pre-filled with relevant context
 4. Scaffolds `.vine/README.md` — a tracked, human/agent-facing orientation doc for using VINE in
    this repo (written for fresh repos; offered, not forced, in upgrade mode)
-5. Optionally adds `.vine/` to `.gitignore` (keeping `.vine/README.md` tracked)
+5. Sets up `.gitignore` for track-by-default — ignores the personal root `.vine.local/` and the
+   session sentinel `.vine/ACTIVE`, leaving the rest of `.vine/` tracked
 6. Introduces the engineer profile (builds organically through vine:verify)
 7. Offers the native hook scaffold — mechanical enforcement of the journal-before-commit
    guarantee, declinable
@@ -375,29 +376,33 @@ project state (CONTEXT.md, SPEC.md, NAVIGATION.md, etc.) separate from configura
 
 ## Step 6: Gitignore
 
-VINE's working state (active projects, profile, ephemera) is workflow state, not repo artifacts,
-and shouldn't be committed by default — but `.vine/README.md` is the one exception: it's a
-tracked orientation doc meant to be shared. So the ignore rule must exclude `.vine/` **while
-keeping the README tracked**.
+VINE tracks its shared working state by default — context overlays, knowledge records, and
+feature projects are repo artifacts meant to travel with the project (work-in-public). Only
+*personal* and *ephemeral* state stays out of git: the personal root `.vine.local/` (your
+profile, personal overlays, local-only projects, pause state) and the active-session sentinel
+`.vine/ACTIVE`.
 
-The target end-state is always the same two lines (alongside any other `.vine` negations):
+The target end-state is these two lines:
 
 ```
-.vine/*
-!.vine/README.md
+.vine.local/
+.vine/ACTIVE
 ```
 
-Use `.vine/*` (ignore the directory's *contents*), not bare `.vine/` (ignore the directory
-itself) — git can't re-include a file whose parent directory is wholly excluded, so a negation
-under a bare `.vine/` silently does nothing. Reconcile whatever's already in `.gitignore` (or the
-user's global gitignore) toward that end-state:
+That's the whole rule. `.vine.local/` ignores the entire personal root in one line; `.vine/ACTIVE`
+keeps the per-worktree session sentinel out of git while the rest of `.vine/` stays tracked — no
+per-file negations, no `!.vine/README.md` exception (the README is tracked because `.vine/` is).
+Reconcile whatever's already in `.gitignore` toward that end-state:
 
-- **No `.vine` ignore yet:** add the two lines.
-- **Already ignored:** normalize a bare `.vine/` to `.vine/*`, then ensure `!.vine/README.md`
-  follows it (add it if missing). Leave any existing negations like `!.vine/context/` in place.
+- **No `.vine` rules yet:** add the two lines.
+- **Legacy ignore-by-default model** (`.vine/*` + `!.vine/README.md`, or a deny-then-allowlist
+  block re-admitting subdirs): replace it wholesale with the two lines above. This flips the repo
+  from "ignore VINE state" to "track it" — Step 8 Upgrade Mode carries the opt-in migration that
+  relocates personal files into `.vine.local/` *before* the flip, so nothing personal leaks into
+  the tracked tree.
 
-If the engineer wants to commit more VINE artifacts (e.g., overlays for team sharing), they can
-add further negations or `git add -f .vine/<path>` selectively.
+A project you'd rather keep off the shared tree lives under `.vine.local/projects/` (vine:verify
+offers this at creation), so the single `.vine.local/` rule covers it with no per-project entries.
 
 ## Step 7: Introduce Engineer Profile
 
@@ -446,6 +451,36 @@ runs. Run the rest of this step in upgrade mode against the existing `.vine/hook
 Don't show this offer in any other condition. If both directories exist, `.vine/context/`
 is canonical (commands read it first) — point out the leftover `.vine/hooks/` directory to
 the engineer instead of guessing which one they meant to keep.
+
+### Track-by-Default Migration
+
+VINE tracks `.vine/` by default and keeps only the personal root `.vine.local/` (plus the
+session sentinel `.vine/ACTIVE`) out of git — see Step 6. A repo set up under the older
+ignore-by-default model — a `.gitignore` carrying `.vine/*` + `!.vine/README.md`, or a
+deny-then-allowlist block re-admitting subdirs — predates that flip. If you detect that model,
+offer the migration via `AskUserQuestion` (`multiSelect: false`, 2 options):
+
+- **"Migrate to track-by-default (Recommended)"** — description: "Relocate personal files into
+  `.vine.local/`, then flip `.gitignore` to the two-line end-state"
+- **"Not now"** — description: "Keep the current `.gitignore` — nothing changes on disk"
+
+**If the engineer accepts**, relocate *before* flipping so nothing personal lands in the tracked
+tree:
+
+1. Move personal/ephemeral files to the personal root (all gitignored today, so plain `mv`;
+   create `.vine.local/` subdirs as needed):
+   - `.vine/context/*.local.md` → `.vine.local/context/<name>.md` (drop the `.local` suffix)
+   - `.vine/PROFILE.md` → `.vine.local/PROFILE.md`
+   - each `.vine/projects/<d>/<f>/PAUSE.md` → `.vine.local/projects/<d>/<f>/PAUSE.md`
+   - `.vine/ACTIVE` does **not** move — it's per-worktree by checkout and stays at `.vine/ACTIVE`
+2. Replace the old `.vine` ignore rules with the Step 6 end-state (`.vine.local/` + `.vine/ACTIVE`).
+3. Verify with `git status` that every previously-tracked `.vine/` artifact is still tracked and
+   nothing personal is newly staged; `git check-ignore` should report `.vine.local/` and
+   `.vine/ACTIVE` ignored, the rest of `.vine/` tracked.
+
+**If the engineer declines**, this is a no-op (#58 rename-fallback): no files move, no `.gitignore`
+edit, and the offer reappears on the next `/vine:init`. Don't show it when `.gitignore` already
+matches the track-by-default end-state.
 
 ### Upgrade Mode
 

--- a/commands/vine/init.md
+++ b/commands/vine/init.md
@@ -299,14 +299,16 @@ feature stands.
 |------|------------|
 | `context/shared.md` | Repo-wide overlay, loaded by every phase |
 | `context/<phase>.md` | Per-phase overlays — `verify.md`, `inquire.md`, `navigate.md`, `evolve.md`, `pair.md` |
-| `context/shared.local.md` | Your personal overlay layer (optional, gitignored) |
 | `projects/<domain>/<feature-slug>/` | Per-feature artifacts: CONTEXT → SPEC → NAVIGATION → EVOLUTION, plus PROJECT-MAP |
-| `PROFILE.md` | Your per-domain expertise, used to tune explanation depth (gitignored) |
 | `scripts/` | Native hook scripts (e.g. `journal-check.sh`) |
-| `ACTIVE`, `projects/**/PAUSE.md` | Ephemeral session state (gitignored) |
+| `ACTIVE` | Ephemeral session sentinel (gitignored, per-worktree) |
 
 `references/STATE.md` in the repo root is the **authoritative** contract for every artifact's
 format and lifecycle. Treat this table as a map; consult STATE.md for the details.
+
+Personal and ephemeral state that shouldn't be committed lives in the sibling **`.vine.local/`**
+root (gitignored, mirrors `.vine/`): your `PROFILE.md`, personal overlays under `context/`, pause
+state, and any local-only feature projects. `.vine/` is tracked by default; `.vine.local/` is not.
 
 ## Context overlays
 
@@ -316,18 +318,19 @@ Each phase composes its context from up to three layers:
    collaboration stance, the validation contract).
 2. **`<phase>.md`** — guidance only one phase needs (which agents `navigate` invokes, what
    `verify` should always explore). These exist only where there's something to add.
-3. **`shared.local.md`** — your personal layer. Gitignored; absent it, nothing changes.
+3. **`.vine.local/context/<name>.md`** — your personal layer, in the gitignored personal root
+   (any overlay can have a personal counterpart at the mirrored path). Absent it, nothing changes.
 
 ### Overlay precedence
 
 The layers resolve as **flat personal-wins with policy carve-outs** — like Claude's own
 settings, where local overrides project except for an immutable policy ceiling:
 
-- **Preference content** (every unmarked section) is personal-overridable: where
-  `shared.local.md` and `shared.md` conflict, your personal layer wins.
+- **Preference content** (every unmarked section) is personal-overridable: where your personal
+  overlay (`.vine.local/context/shared.md`) and `shared.md` conflict, your personal layer wins.
 - **Policy content** is immutable from the personal layer. A section marked
   `<!-- class: policy -->` directly under its heading (e.g. **Team Context**, **CI/CD**) always
-  wins; `shared.local.md` can't weaken or replace it.
+  wins; your personal overlay can't weaken or replace it.
 
 Only policy-class sections carry the marker — unmarked means preference.
 

--- a/commands/vine/verify.md
+++ b/commands/vine/verify.md
@@ -239,8 +239,10 @@ Use them verbatim. Extending a heading with subtitle text after a colon or dash 
 not. Downstream phases and artifact-format validation locate sections by these headings, so
 a custom heading breaks the chain silently.
 
-Save this to a domain-namespaced directory under `.vine/projects/`. The path follows the pattern:
-`.vine/projects/<domain>/<feature-slug>/CONTEXT.md`
+Save this to a domain-namespaced directory. The path follows the pattern
+`<root>/projects/<domain>/<feature-slug>/CONTEXT.md`, where `<root>` is `.vine/` for a shared
+project (the default) or `.vine.local/` for a local one — the **Shared or local?** prompt below
+decides which. The examples here show the shared default:
 
 The domain is the root area or module the feature lives in — not the repo name, but the
 logical domain the work touches. For example:
@@ -259,10 +261,21 @@ an "Other" option for custom input. Follow up with a second prompt for the featu
 
 Confirm both before creating the directory.
 
-If this is the first VINE cycle in this repo, suggest adding `.vine/` to `.gitignore`. The
-artifacts are valuable for the engineer's workflow but don't need to be committed until the
-team decides they want them in the repo. If the engineer later wants to share VINE artifacts
-(for example, opening a PR with the feature), they can `git add -f .vine/` selectively.
+**Shared or local?** Once the domain and slug are confirmed, decide which root the project lives
+under. Use `AskUserQuestion` (one question, per the Interaction Constraints in `shared.md`):
+
+- **"Shared — commit with the repo (Recommended)"**: create under
+  `.vine/projects/<domain>/<feature-slug>/`. This is the default — `.vine/` is tracked, so the
+  artifacts travel with the repo and fit working in public. Most projects want this.
+- **"Keep this local"**: create under `.vine.local/projects/<domain>/<feature-slug>/` instead. The
+  `.vine.local/` root is gitignored entirely, so the project stays on this machine — nothing about
+  it enters a commit. Use this for spikes, throwaway exploration, or work you're not ready to share.
+
+Resolve `.vine.local/` at the shared personal root (the repo's primary worktree), per *The two
+roots* in `references/STATE.md` — not cwd, so the choice holds across worktrees. Whichever root the
+engineer picks, the rest of the cycle follows it automatically: discovery scans both roots, and the
+per-path commit test (Sign-Off Gate, below) commits a shared project and skips a local one with no
+special-casing.
 
 This file is the contract between verify and inquire — everything inquire needs to know about
 the landscape should be here.

--- a/references/STATE.md
+++ b/references/STATE.md
@@ -405,7 +405,7 @@ Unlike per-feature artifacts, PROFILE.md lives at `.vine.local/PROFILE.md` (unde
 
 ### README.md (seeded by vine:init)
 
-`.vine/README.md` is a human/agent-facing orientation doc explaining how to *use* VINE inside this repo — what lives under `.vine/`, how context overlays compose (precedence, the `.local` layer), the optional `## Validation` block, and how to customize VINE for the repo. It is the one tracked file under `.vine/` by default (init's gitignore step adds a `!.vine/README.md` negation); everything else is workflow state or gitignored.
+`.vine/README.md` is a human/agent-facing orientation doc explaining how to *use* VINE inside this repo — what lives under `.vine/`, how context overlays compose (precedence, the personal `.vine.local/` layer), the optional `## Validation` block, and how to customize VINE for the repo. It is tracked like everything else under `.vine/` (track-by-default — only `.vine.local/` and the `.vine/ACTIVE` sentinel are gitignored).
 
 Unlike the overlays, the README configures nothing — overlays steer VINE's behavior, the README documents it. It points back to this file (STATE.md) for the authoritative artifact structure rather than duplicating it, so it can't drift from the contract.
 


### PR DESCRIPTION
## What

VINE now tracks its `.vine/` directory by default and keeps everything personal in a new gitignored sibling root, **`.vine.local/`** (your profile, personal overlays, pause state, and any local-only feature projects). The root `.gitignore` collapses from a brittle deny-then-allowlist to a single rule. New features default to **shared** (committed with the repo); `vine:verify` offers a one-tap "keep local" option, and `vine:evolve` can promote a local feature to shared at wrap-up. `vine:init` scaffolds the new gitignore for fresh repos and offers existing repos an opt-in migration where declining changes nothing.

## Why

The shared `.vine/` tree is meant to travel with the repo (work-in-public), while one machine's personal state shouldn't be committed — the old allowlist made every new tracked subdirectory a silent footgun. Rather than prescribe a team-overlay format, VINE ships the personal/shared split and points teams at primitives they already have (a tracked `shared.md` plus the policy-class marker).

Refs #52 (cycle wrap-up — EVOLUTION + decision record land via `vine:evolve`).
Closes #108 (the gitignore inversion this cycle was gated on).

## How to test

1. `git check-ignore .vine/context/shared.md .vine.local/PROFILE.md` — first reads as tracked, second as ignored.
2. Run `/vine:verify` and confirm the new "Shared or local?" prompt routes a local feature into `.vine.local/projects/`.
3. `/trellis` passes (11/11 commands, 8 anchor pairs).

## Checklist

- [x] Tested in a VINE cycle (command behavior changed)
- [x] Focused on a single concern
- [x] New behavior documented in README + command files

*Maintainer roadmap work for #52 (touches command behavior + the directory/state model); see #52/#108 for discussion.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
