### PR TITLE
vine-reviewer: pin validation discovery to the ## Validation heading

### DIFF
--- a/agents/vine-reviewer.md
+++ b/agents/vine-reviewer.md
@@ -57,7 +57,12 @@ Read in this order; later items will make sense because of earlier ones:
 When you re-run cheap checks, discover the commands in priority order — don't assume a fixed set:
 
 1. The `## Validation` block in `.vine/context/shared.md` — a fenced YAML contract with optional keys
-   `lint` / `typecheck` / `test` / `test-all` / `build` / `extra`. Run the keys that are present;
+   `lint` / `typecheck` / `test` / `test-all` / `build` / `extra`. **Locate it precisely**: grep for
+   the literal `## Validation` heading (`grep -n '^## Validation' .vine/context/shared.md`) — it is a
+   top-level section, typically near the end of the file — then read the fenced ```yaml block beneath
+   it. Do **not** infer its absence from prose: the `## Decision Delegation` section discusses
+   "validation" in prose and is **not** this block, and a `grep validation` substring scan will hit
+   that section and other mentions. Only the heading match counts. Run the keys that are present;
    ignore absent ones. When the block exists it is authoritative.
 2. Prose inference (fallback — no block, or it omits a check): `package.json` scripts, config files
    (`.eslintrc`, `tsconfig.json`, `pyproject.toml`, `Makefile`), the `.vine/context/*.md` overlays,


### PR DESCRIPTION
## What

Sharpen the `vine-reviewer` agent's validation-command discovery step so a cold reviewer reliably finds the repo's `## Validation` contract. It now greps for the literal `## Validation` heading and reads the fenced YAML block beneath it, and explicitly avoids mistaking the `## Decision Delegation` section (which mentions "validation" in prose) for the block. The prose-inference fallback for repos that genuinely lack the block is unchanged.

## Why

A `/pr-review` dogfood run against #126 had the reviewer report "No fenced `## Validation` YAML block in `.vine/context/shared.md`" and fall back to prose inference — but the block does exist (heading at `shared.md:297`, YAML at line 311 declaring `extra: - sh .vine/scripts/trellis-check.sh`). The agent landed on the right validation command by luck; a less forgiving repo would have produced a wrong or incomplete review. The loose lookup was the cause, so this pins it to the heading.

This is a recipe sharpening only — no change to `references/STATE.md`, the artifact templates, or the `## Validation` contract itself.

## How to test

1. Read `agents/vine-reviewer.md` → *Discovering Validation Commands*, step 1: it greps `^## Validation` and warns against the `## Decision Delegation` false match.
2. `/trellis` passes (11/11 commands, 8/8 cross-reference anchors).

## Checklist

- [x] Changes are focused on a single concern
- [x] `/trellis` passes (agents/ is not gated, but the check is green)