### PR TITLE
journal-check: emit a visible signal on fire-and-pass

### DIFF
--- a/.vine/scripts/journal-check.sh
+++ b/.vine/scripts/journal-check.sh
@@ -52,7 +52,14 @@ last=$(git -C "$root" log -1 --format=%ct 2>/dev/null)
 # -ge, not -gt: mtimes have second granularity, and a journal touched in the
 # same second as HEAD's commit was plausibly updated alongside it — ties fail
 # open like every other ambiguous path here.
+#
+# This is the only fire-and-pass exit: the guard reached a real commit in an
+# active session, found the journal, and confirmed it's current. Emit one
+# stderr line so a reviewer can tell "fired and passed" apart from "never
+# fired" (both exit 0). Low-noise by construction — it prints once per allowed
+# commit, not on the fail-open early exits above.
 if [ "$mtime" -ge "$last" ] 2>/dev/null; then
+  echo "VINE journal guard: $feature/NAVIGATION.md is current — commit allowed." >&2
   exit 0
 fi
 

--- a/.vine/scripts/run-tests.sh
+++ b/.vine/scripts/run-tests.sh
@@ -45,8 +45,18 @@ printf '%s' "$payload_commit" | sh "$J" >/dev/null 2>&1
 check "journal-check: stale journal -> block (exit 2)" 2 $?
 
 touch "$T/feat/NAVIGATION.md"
-printf '%s' "$payload_commit" | sh "$J" >/dev/null 2>&1
+ferr=$(printf '%s' "$payload_commit" | sh "$J" 2>&1 >/dev/null)
 check "journal-check: fresh journal (same-second tie fails open) -> allow" 0 $?
+printf '%s' "$ferr" | grep -q 'journal guard:.*commit allowed'
+check "journal-check: fire-and-pass emits a visible signal on stderr" 0 $?
+
+# The fail-open early exits must stay silent — only the real fire-and-pass
+# path signals, so the note never spams routine no-session/non-commit calls.
+rm "$T/.vine/ACTIVE"
+nserr=$(printf '%s' "$payload_commit" | sh "$J" 2>&1 >/dev/null)
+check "journal-check: no sentinel (didn't fire) -> allow" 0 $?
+printf '%s' "$nserr" | grep -q 'journal guard'
+check "journal-check: didn't-fire path stays silent (no signal)" 1 $?
 
 rm -rf "$T"
 


### PR DESCRIPTION
## What

The navigate-session journal guard (`.vine/scripts/journal-check.sh`) now prints one stderr line when it actually runs and allows a commit:

```
VINE journal guard: <feature>/NAVIGATION.md is current — commit allowed.
```

## Why

The guard exits 0 in two very different situations: when it never fired (no active session) and when it fired, checked a current journal, and allowed the commit. Both were silent, so a reviewer had no way to confirm the hook ran during a headless or interactive session. The signal is emitted only on the genuine fire-and-pass path — every fail-open early exit stays quiet, so it prints once per allowed commit, not on routine invocations.

Contributor-only scripts; nothing shipped by create-vine changes.

Closes #99

## How to test

1. `sh .vine/scripts/run-tests.sh` — all cases pass, including the two new ones (signal fires on pass; no-sentinel path stays silent).
2. `sh .vine/scripts/trellis-check.sh` — passes.

## Checklist

- [x] Changes are focused on a single concern
- [x] New behavior is covered by run-tests.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)