### PR TITLE
Resolve the personal root via git-common-dir in the loading surface (#132)

### DIFF
--- a/.claude/commands/trellis.md
+++ b/.claude/commands/trellis.md
@@ -169,6 +169,28 @@ The floor covers the product surface (command files). The same rule applies by c
 artifact chain and decision records, but enforcement there rides the writing commands, not this
 linter — and never runs retroactively against immutable historical artifacts.
 
+### Check 12: Personal-Root Resolution (repo-level)
+
+The high-frequency profile and personal-overlay reads must resolve the **shared personal root**
+via `dirname "$(git rev-parse --git-common-dir)"` before reading `.vine.local/PROFILE.md` /
+`context/<name>.md`, never a bare cwd-relative `.vine.local/` read — which a linked git worktree
+does not check out, so the read silently returns nothing (issue #132). The contract lives in
+`.vine/context/shared.md`: a named helper, **Resolving the personal root**, defined once in the
+Overlay Loading Protocol and referenced from the Personal-layer rule and the Engineer Profile
+Protocol.
+
+Like Check 10 this is repo-level, not per-command, and inspects only `.vine/context/shared.md`
+(command files inherit the fix by deferring to these protocols). It asserts:
+
+- the helper is defined — `.vine/context/shared.md` contains the literal `**Resolving the personal
+  root.**`; and
+- the `## Engineer Profile Protocol` section references `Resolving the personal root` (reverting it
+  to a bare cwd-relative `.vine.local/PROFILE.md` read drops the phrase and trips the check).
+
+A gap is a **failure** that counts toward pass/fail, mirroring Check 10. Skipped when `shared.md`
+is absent (it is optional). The same two assertions live in `.vine/scripts/trellis-check.sh` — keep
+them in sync.
+
 ## Step 4: Format Results
 
 Present results as a summary table with commands as rows and checks as columns:
@@ -216,6 +238,12 @@ After the warnings, print the Check 10 anchor result as its own line:
 - Any missing: **"❌ N cross-reference anchor(s) missing"** followed by one line per missing
   pair (file and expected anchor). Unlike Check 9's warnings, anchor failures count toward
   the pass/fail status the stamp records (Step 8).
+
+Then print the Check 12 personal-root result as its own line:
+
+- Wired: **"✅ Personal-root resolution wired into shared.md (#132 guard)"**
+- Any gap: **"❌ N personal-root resolution gap(s) in shared.md"** followed by one line per gap.
+  Like Check 10, gaps count toward the pass/fail status.
 
 The combined summary (covering both command and artifact results) is printed in Step 7.
 

--- a/.vine/context/shared.md
+++ b/.vine/context/shared.md
@@ -9,15 +9,28 @@ reads `.vine/context/shared.md` and `.vine/context/<phase>.md` (and is the step 
 file in the first place, so it cannot be fully externalized); everything below is what "follow
 the Overlay Loading Protocol" pulls in.
 
+**Resolving the personal root.** The personal tree `.vine.local/` is gitignored, so it is *not*
+checked out into a linked git worktree — reading it cwd-relative would make a worktree (or
+delegated) session silently see no profile and no personal overlays. So before any read or write
+under `.vine.local/` (PROFILE.md, `context/<name>.md`, local projects, pause state), resolve the
+shared personal root at the repository's **primary** worktree — `dirname "$(git rev-parse
+--git-common-dir)"` — and operate on `<personal-root>/.vine.local/…` there. That path is identical
+from every linked worktree, so one profile / overlay set is seen everywhere; in a single checkout it
+resolves to the same directory as cwd, so behavior is unchanged. A non-git directory falls back to
+the cwd-relative `./.vine.local/`. (The `.vine/ACTIVE` sentinel is the lone exception — it stays
+cwd-relative by design; only the shared personal root needs git resolution.) Full rule and
+rationale: *The two roots → Resolving the roots* in `references/STATE.md`.
+
 - **Apply as overlay instructions.** Treat the contents of both files as additional instructions
   layered on top of the command. Overlay instructions take precedence over command defaults when
   they conflict — they are the team's customization of VINE for this codebase. (Precedence
   *between* the overlay layers — shared vs. personal vs. policy — is governed by **Overlay
   Precedence** below; that section is the source of truth and this line does not override it.)
 - **Personal layer.** After reading each repo overlay from `.vine/context/` (`shared.md` and the
-  phase overlay), read its personal counterpart at the mirrored path under the personal root —
-  `.vine.local/context/<name>.md` (e.g. `.vine.local/context/shared.md`,
-  `.vine.local/context/<phase>.md`) — and compose it per the **Personal layer** rule in Overlay
+  phase overlay), read its personal counterpart at the mirrored path under the resolved personal
+  root (**Resolving the personal root** above) —
+  `<personal-root>/.vine.local/context/<name>.md` (e.g. `…/.vine.local/context/shared.md`,
+  `…/.vine.local/context/<phase>.md`) — and compose it per the **Personal layer** rule in Overlay
   Precedence. The personal overlay is distinguished by its root, not a filename suffix (the `.local`
   suffix is dropped). Absent any personal file, nothing changes.
 - **Legacy fallback (supported through 0.4.x).** If `.vine/context/` doesn't exist but legacy
@@ -49,7 +62,8 @@ except an immutable enterprise-policy ceiling:
 
 **Personal layer (`.vine.local/context/`).** Each command's *Load Context Overlays* step, after
 reading a repo overlay (`shared.md`, a phase overlay), reads its personal counterpart at the
-mirrored path `.vine.local/context/<name>.md` if present and composes it by the rule above — it
+mirrored path `<personal-root>/.vine.local/context/<name>.md` (resolved per **Resolving the personal
+root** in the Overlay Loading Protocol) if present and composes it by the rule above — it
 overrides preference content and is ignored where it would override a policy-class section. Personal
 overlays live under the gitignored personal root (`.vine.local/`); absent them, nothing changes.
 
@@ -236,8 +250,9 @@ Internal, not shown to the engineer. Apply this stance in all VINE phases:
 
 ## Engineer Profile Protocol
 
-After loading overlays, check for `.vine.local/PROFILE.md`. If it exists, read the Domain Expertise
-table. Match the feature's domain against the profile's entries.
+After loading overlays, resolve the shared personal root (**Resolving the personal root** in the
+Overlay Loading Protocol) and check for `<personal-root>/.vine.local/PROFILE.md`. If it exists, read
+the Domain Expertise table. Match the feature's domain against the profile's entries.
 
 - **If the domain is in the profile**: Note their level for this session. Use it to calibrate
   default engagement depth (confident/familiar = concise; learning/new = explain the why).

--- a/.vine/knowledge/workflow/2026-06-22-anchor-the-personal-root-at-the-repo-shared-across-worktrees.md
+++ b/.vine/knowledge/workflow/2026-06-22-anchor-the-personal-root-at-the-repo-shared-across-worktrees.md
@@ -107,3 +107,20 @@ Two simple globs, still far less brittle than the deny-then-allowlist #108 remov
 **Unchanged.** The shared-personal-root anchoring (`dirname "$(git rev-parse --git-common-dir)"` for
 profile, overlays, local projects, pause) — the core fix this record exists for — stands exactly as
 decided.
+
+## Amendment (issue #132): loading surface adopts the resolution
+
+When this record shipped, the contract (`references/STATE.md`) and this ADR specified git-anchored
+resolution of the shared personal root, but the two high-frequency read protocols in
+`.vine/context/shared.md` — the Engineer Profile Protocol and the Overlay Loading Protocol's
+Personal-layer rule — still read cwd-relative `.vine.local/…`. From a linked worktree, where
+`.vine.local/` is gitignored and not checked out, those reads silently returned nothing — the
+"short-term stopgap" (the symlink, Consequences above) was the only thing bridging the gap.
+
+Issue #132 closes it. `shared.md` now defines the resolution once as a named helper — **Resolving
+the personal root** — in the Overlay Loading Protocol, and the Personal-layer rule and Engineer
+Profile Protocol reference it before any `PROFILE.md` / `context/<name>.md` read. The
+profile-writing command paths (`verify`, `evolve`) and `status`'s inline read were routed through
+the same resolution; `init` carries the matching scaffold. A `trellis` Check 12 guards against a
+cwd-relative read regressing. The symlink stopgap is now obsolete. `ACTIVE` is untouched, per the
+Slice 5 amendment above.

--- a/.vine/scripts/trellis-check.sh
+++ b/.vine/scripts/trellis-check.sh
@@ -23,6 +23,9 @@
 # Plus one repo-level check (not per-command, no table column):
 #  10 Cross-reference anchors resolve (verification-tier contract family:
 #     STATE.md note, agent mode/scope names, command pointers) -> FAILURE
+#  12 Personal-root resolution wired into shared.md — the profile/overlay reads
+#     route through the "Resolving the personal root" helper, not a bare
+#     cwd-relative .vine.local/ read (#132 regression guard) -> FAILURE
 #
 # Writes .vine/.trellis-ok in the format the gate expects: a "status: pass"
 # (or "status: fail") first line. Warnings never change pass/fail (matches the
@@ -310,6 +313,34 @@ if [ "$ANCHOR_TOTAL" -eq 0 ]; then
   - PAIRS list is empty — the anchor check verified nothing"
 fi
 
+# ---------- Check 12: personal-root resolution wired into shared.md ----------
+# Guards #132: the high-frequency profile/overlay reads in shared.md's protocols
+# must route through the "Resolving the personal root" helper, never a bare
+# cwd-relative `.vine.local/` read — which a linked git worktree does not check
+# out, so the read silently returns nothing. FAILURE. Skipped when shared.md is
+# absent (it is optional). Only inspects shared.md: command files inherit the
+# fix by deferring to these protocols.
+
+SHARED="$root/.vine/context/shared.md"
+RESOLVE_ISSUES=0
+RESOLVEDETAIL=""
+if [ -f "$SHARED" ]; then
+  # (a) the helper must be defined (lives in the Overlay Loading Protocol).
+  if ! grep -qF '**Resolving the personal root.**' "$SHARED"; then
+    RESOLVE_ISSUES=$((RESOLVE_ISSUES + 1))
+    RESOLVEDETAIL="$RESOLVEDETAIL
+  - shared.md — missing the \`**Resolving the personal root.**\` helper definition"
+  fi
+  # (b) the Engineer Profile Protocol must reference it — reverting to a bare
+  #     cwd-relative PROFILE.md read drops this phrase and trips the check.
+  epp=$(awk '/^## Engineer Profile Protocol/{f=1; next} f && /^## /{exit} f{print}' "$SHARED")
+  if ! printf '%s\n' "$epp" | grep -qF 'Resolving the personal root'; then
+    RESOLVE_ISSUES=$((RESOLVE_ISSUES + 1))
+    RESOLVEDETAIL="$RESOLVEDETAIL
+  - shared.md — Engineer Profile Protocol must route the PROFILE.md read through 'Resolving the personal root' (bare cwd-relative read regresses #132)"
+  fi
+fi
+
 echo
 if [ "$ISSUE_COUNT" -eq 0 ]; then
   SUMMARY="✅ $TOTAL/$TOTAL commands pass all checks"
@@ -327,7 +358,15 @@ fi
 echo "$ANCHOR_SUMMARY"
 [ -n "$ANCHORDETAIL" ] && printf '%s\n' "$ANCHORDETAIL"
 
-if [ "$ISSUE_COUNT" -eq 0 ] && [ "$ANCHOR_ISSUES" -eq 0 ]; then
+if [ "$RESOLVE_ISSUES" -eq 0 ]; then
+  RESOLVE_SUMMARY="✅ Personal-root resolution wired into shared.md (#132 guard)"
+else
+  RESOLVE_SUMMARY="❌ $RESOLVE_ISSUES personal-root resolution gap(s) in shared.md"
+fi
+echo "$RESOLVE_SUMMARY"
+[ -n "$RESOLVEDETAIL" ] && printf '%s\n' "$RESOLVEDETAIL"
+
+if [ "$ISSUE_COUNT" -eq 0 ] && [ "$ANCHOR_ISSUES" -eq 0 ] && [ "$RESOLVE_ISSUES" -eq 0 ]; then
   STATUS="pass"
 else
   STATUS="fail"
@@ -352,7 +391,7 @@ mkdir -p "$root/.vine"
 {
   echo "status: $STATUS"
   echo "checked: $when"
-  echo "summary: $SUMMARY; $ANCHOR_SUMMARY"
+  echo "summary: $SUMMARY; $ANCHOR_SUMMARY; $RESOLVE_SUMMARY"
 } > "$STAMP"
 
 [ "$STATUS" = pass ]

--- a/commands/vine/evolve.md
+++ b/commands/vine/evolve.md
@@ -305,8 +305,11 @@ say so and move on — not every feature is a learning experience.
 
 ### Update Engineer Profile
 
-Based on the completed cycle, propose updates to `.vine.local/PROFILE.md`. This is the concrete,
-persistent output of user evolution — the profile grows with each VINE cycle.
+Based on the completed cycle, propose updates to `PROFILE.md` at the resolved shared personal root
+(**Resolving the personal root** in `shared.md`'s Overlay Loading Protocol —
+`<personal-root>/.vine.local/PROFILE.md`, not cwd, so the profile is read and written at the same
+place from every worktree). This is the concrete, persistent output of user evolution — the profile
+grows with each VINE cycle.
 
 **Domain expertise update:**
 
@@ -348,8 +351,9 @@ only when the engineer genuinely wants to record something. If they choose the d
 write bullet points focused on the engineer's contributions and decisions — not what they
 "learned." Present the draft for editing before writing to the file.
 
-For each accepted change, write the update to `.vine.local/PROFILE.md` directly. Create the file
-if needed, using the format documented in `references/STATE.md`.
+For each accepted change, write the update to the resolved-root `PROFILE.md` directly (the
+`<personal-root>/.vine.local/PROFILE.md` resolved above). Create the file if needed, using the
+format documented in `references/STATE.md`.
 
 ### Suggest Claude Memory Updates
 

--- a/commands/vine/init.md
+++ b/commands/vine/init.md
@@ -91,14 +91,27 @@ file plus its phase overlay, then defers here for the shared loading rules. The 
 in the first place, so it cannot be fully externalized); the rules below are what "follow the
 Overlay Loading Protocol" pulls in.
 
+**Resolving the personal root.** The personal tree `.vine.local/` is gitignored, so it is *not*
+checked out into a linked git worktree — reading it cwd-relative would make a worktree (or
+delegated) session silently see no profile and no personal overlays. So before any read or write
+under `.vine.local/` (PROFILE.md, `context/<name>.md`, local projects, pause state), resolve the
+shared personal root at the repository's **primary** worktree — `dirname "$(git rev-parse
+--git-common-dir)"` — and operate on `<personal-root>/.vine.local/…` there. That path is identical
+from every linked worktree, so one profile / overlay set is seen everywhere; in a single checkout it
+resolves to the same directory as cwd, so behavior is unchanged. A non-git directory falls back to
+the cwd-relative `./.vine.local/`. (The `.vine/ACTIVE` sentinel is the lone exception — it stays
+cwd-relative by design; only the shared personal root needs git resolution.) Full rule and
+rationale: *The two roots → Resolving the roots* in `references/STATE.md`.
+
 - **Apply as overlay instructions.** Treat both files' contents as instructions layered on top
   of the command; overlay instructions take precedence over command defaults when they conflict.
   (Precedence *between* the overlay layers — shared vs. personal vs. policy — is governed by
   **Overlay Precedence** below, the source of truth; this line does not override it.)
 - **Personal layer.** After reading each repo overlay from `.vine/context/` (`shared.md` and the
-  phase overlay), read its personal counterpart at the mirrored path under the personal root —
-  `.vine.local/context/<name>.md` (e.g. `.vine.local/context/shared.md`,
-  `.vine.local/context/<phase>.md`) — and compose it per the **Personal layer** rule in Overlay
+  phase overlay), read its personal counterpart at the mirrored path under the resolved personal
+  root (**Resolving the personal root** above) —
+  `<personal-root>/.vine.local/context/<name>.md` (e.g. `…/.vine.local/context/shared.md`,
+  `…/.vine.local/context/<phase>.md`) — and compose it per the **Personal layer** rule in Overlay
   Precedence. The personal overlay is distinguished by its root, not a filename suffix (the `.local`
   suffix is dropped). Absent any personal file, nothing changes.
 - **Legacy fallback (supported through 0.4.x).** If `.vine/context/` doesn't exist but legacy
@@ -128,7 +141,8 @@ except an immutable enterprise-policy ceiling:
 
 **Personal layer (`.vine.local/context/`).** Each command's *Load Context Overlays* step, after
 reading a repo overlay (`shared.md`, a phase overlay), reads its personal counterpart at the
-mirrored path `.vine.local/context/<name>.md` if present and composes it by the rule above — it
+mirrored path `<personal-root>/.vine.local/context/<name>.md` (resolved per **Resolving the personal
+root** in the Overlay Loading Protocol) if present and composes it by the rule above — it
 overrides preference content and is ignored where it would override a policy-class section. Personal
 overlays live under the gitignored personal root (`.vine.local/`); absent them, nothing changes.
 
@@ -178,8 +192,9 @@ Internal, not shown to the engineer. Apply this stance in all VINE phases:
 
 ## Engineer Profile Protocol
 
-After loading overlays, check for `.vine.local/PROFILE.md`. If it exists, read the Domain Expertise
-table. Match the feature's domain against the profile's entries.
+After loading overlays, resolve the shared personal root (**Resolving the personal root** in the
+Overlay Loading Protocol) and check for `<personal-root>/.vine.local/PROFILE.md`. If it exists, read
+the Domain Expertise table. Match the feature's domain against the profile's entries.
 
 - **If the domain is in the profile**: Note their level for this session. Use it to calibrate
   default engagement depth (confident/familiar = concise; learning/new = explain the why).
@@ -419,8 +434,9 @@ After generating overlays, briefly mention the engineer profile to the engineer:
 Do **not** ask any domain rating questions here. The profile seeds itself through vine:verify
 as the engineer works in different domains. This step is purely informational.
 
-If `.vine.local/PROFILE.md` already exists (e.g., from a previous init or manual creation), skip
-this message entirely.
+If `PROFILE.md` already exists at the resolved shared personal root (**Resolving the personal root**
+in the Overlay Loading Protocol — `<personal-root>/.vine.local/PROFILE.md`), e.g. from a previous
+init or manual creation, skip this message entirely.
 
 ## Step 8: Upgrade Existing Projects
 

--- a/commands/vine/status.md
+++ b/commands/vine/status.md
@@ -22,7 +22,10 @@ gracefully: read the phase overlay if present, otherwise proceed on command defa
 
 ## Load Engineer Profile
 
-After loading overlays, check for the engineer's profile at `.vine.local/PROFILE.md`.
+After loading overlays, resolve the shared personal root (**Resolving the personal root** in
+`shared.md`'s Overlay Loading Protocol) and check for the engineer's profile at
+`<personal-root>/.vine.local/PROFILE.md` — resolved, not cwd-relative, so a worktree session sees
+the same profile as the main checkout.
 
 If it exists, note it for the status display. No depth hint needed — status is a read-only
 display command.

--- a/commands/vine/verify.md
+++ b/commands/vine/verify.md
@@ -42,8 +42,11 @@ that seeds new domains:
   3. "Learning" — "I've seen it but haven't worked in it much"
   4. "New" — "This is my first time in this area"
 
-  Add the domain to `.vine.local/PROFILE.md` with the selected level and today's date. If
-  PROFILE.md doesn't exist yet, create it with the format documented in `references/STATE.md`.
+  Add the domain to `PROFILE.md` at the resolved shared personal root (**Resolving the personal
+  root** in `shared.md`'s Overlay Loading Protocol — `<personal-root>/.vine.local/PROFILE.md`, not
+  cwd, so the profile is written and read at the same place from every worktree) with the selected
+  level and today's date. If PROFILE.md doesn't exist there yet, create it with the format
+  documented in `references/STATE.md`.
 
 If no profile exists and the engineer hasn't confirmed a domain yet, do nothing — the prompt
 happens naturally when the domain is confirmed during CONTEXT.md creation. No upfront questions.


### PR DESCRIPTION
## What

Fixes VINE silently running with **no engineer profile and no personal overlays** in any `git worktree` or delegated session. The fix routes the high-frequency profile and personal-overlay reads through a git-anchored resolution of the personal root, instead of reading a cwd-relative path that a worktree doesn't have.

## Why

The personal state (profile, personal overlays) lives in `.vine.local/`, which is gitignored — so it is **not** checked out into a linked worktree. The loading protocols read it cwd-relative, so from a worktree the read returned nothing: every worktree session and delegated agent run behaved as if no profile existed. The correct git-anchored resolution was already written into `references/STATE.md` and the workflow decision record, but the protocols every command runs had never adopted it.

The protocols now resolve the personal root at the main checkout (`dirname "$(git rev-parse --git-common-dir)"`, defined once as a named helper) before reading. Single-checkout sessions are unaffected — that command resolves to the same directory as the working directory there, and a non-git directory falls back to today's `./.vine.local/`. No artifact formats change. `.vine/ACTIVE` is deliberately left cwd-relative.

Closes #132

## How to test

1. From a `git worktree` of a repo that has a `.vine.local/PROFILE.md` in its main checkout, run `/vine:status` — it now reports the profile (previously it found none).
2. Run `sh .vine/scripts/trellis-check.sh` — passes, including the new "Personal-root resolution wired into shared.md (#132 guard)" line.
3. Confirm `dirname "$(git rev-parse --git-common-dir)"` prints the main checkout root from both the main checkout and a linked worktree.

## Checklist

- [x] I've tested this in an actual VINE cycle (if changing command behavior)
- [x] Changes are focused on a single concern
- [x] Any new behavior is documented in the README or command file