### PR TITLE
Plugin packaging (1/4): manifest, marketplace + first skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "moduloMoments",
+  "owner": {
+    "name": "moduloMoments",
+    "url": "https://github.com/moduloMoments/VINE"
+  },
+  "metadata": {
+    "description": "moduloMoments plugins for Claude Code — home of VINE, the AI-assisted feature development workflow"
+  },
+  "plugins": [
+    {
+      "name": "vine",
+      "source": "./"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "vine",
+  "version": "0.4.0",
+  "description": "VINE — AI-assisted feature development workflow for Claude Code (verify → inquire → navigate → evolve)",
+  "author": {
+    "name": "moduloMoments",
+    "url": "https://github.com/moduloMoments/VINE"
+  }
+}

--- a/.vine/projects/workflow/plugin-packaging/CONTEXT.md
+++ b/.vine/projects/workflow/plugin-packaging/CONTEXT.md
@@ -1,0 +1,113 @@
+# Feature Context: Claude Code Plugin Packaging + Team-Overlay Distribution
+## Date: 2026-06-22
+## Author: Rob + Claude
+
+Cycle 5 of the v0.4.0 roadmap (issue [#57](https://github.com/moduloMoments/VINE/issues/57)).
+Package VINE as a native Claude Code plugin distributed via a marketplace, *and* make that plugin
+the carrier for team/company overlay content — while keeping the existing `npx create-vine` flow
+working (backward compatibility is the roadmap's hard gate).
+
+### Codebase Landscape
+
+The distribution surface today is small and file-copy based:
+
+- **`bin/cli.js`** — the `create-vine` installer. Copies `commands/vine/*.md` → `.claude/commands/vine/`
+  and `agents/*.md` → `.claude/agents/` (project or `--global`). Project installs also copy an
+  allowlisted scaffold script (`journal-check.sh`) into `.vine/scripts/`; the allowlist deliberately
+  excludes contributor-only scripts (`trellis-gate.sh`, `main-guard.sh`). On re-run it detects an
+  upgrade and nudges `/vine:init`.
+- **`package.json`** — name `create-vine`, version `0.3.0` (not yet bumped to 0.4.0 despite the
+  `[Unreleased]` 0.4.0 CHANGELOG block). `files` allowlist controls what npm ships: `bin`,
+  `commands/vine`, `agents`, and the single scaffold script.
+- **`.github/workflows/publish.yml`** — manual `workflow_dispatch` only. Reads version from
+  package.json, extracts the matching CHANGELOG section, smoke-tests `bin/cli.js` in a temp dir,
+  `npm publish --provenance`, then tags + creates a GitHub release.
+- **The product** — 11 command files (`commands/vine/*.md`, frontmatter `name: vine:navigate` etc.,
+  colon-namespaced) and 4 agents (`agents/*.md`: vine-codebase-explorer, vine-verification,
+  vine-coder, vine-reviewer; frontmatter `name`/`description`/`tools`/`model`). Note: the npx
+  installer only copies *commands and agents*; the contributor agents (coder/reviewer) ship too
+  since `files` includes all of `agents/`.
+- **Overlay surface** — team/company conventions live in the tracked `.vine/context/shared.md`,
+  governed by the `<!-- class: policy -->` marker (immutable from the personal `.vine.local/` layer).
+  Per the team-layer ADR, this overlay content is what the plugin must distribute cross-repo.
+
+### Current State — Platform Schema Verified
+
+Claude Code plugin/marketplace schema confirmed against current docs (code.claude.com/docs) via the
+claude-code-guide agent:
+
+- **Manifest** `.claude-plugin/plugin.json` + **marketplace** `.claude-plugin/marketplace.json` can
+  co-live in one repo → users run `claude plugin marketplace add <repo>` then install. Only `name`
+  is required in the manifest; component dirs (`commands/`, `agents/`, `hooks/`, `skills/`) are
+  auto-discovered at the plugin **root** (not inside `.claude-plugin/`).
+- **Namespace survives.** Frontmatter `name: vine:navigate` is honored as-is — the plugin name does
+  **not** auto-prefix — so `/vine:*` invocation is unchanged loaded as a plugin. This is load-bearing
+  for the backward-compat gate.
+- **Agents behave identically.** Description-based auto-delegation works the same loaded via plugin
+  vs. copied into `.claude/agents/`.
+- **Hooks shippable.** A plugin can wire hooks via `hooks/hooks.json` using `${CLAUDE_PLUGIN_ROOT}`
+  — a possible native home for `journal-check.sh` (today copied by the npx installer).
+- **Version sources can pin or float.** Set `version` to pin; omit to use git SHA. Setting it in both
+  plugin.json and the marketplace entry is redundant (plugin.json wins silently).
+
+### Edge Cases & Tribal Knowledge
+
+- **Single repo is both the contributor tree and the plugin root.** VINE's files are nested at
+  `commands/vine/*.md`, but a plugin auto-discovers `commands/*.md` at its root. Whether the plugin
+  lives at repo root, a `plugins/<name>/` subdir, or restructures the tree is an open design fork
+  (see Open Questions). This is the central structural tension.
+- **Coexistence duplicates, doesn't collide.** A user who installed via npx (`.claude/commands/vine/`)
+  *and* installs the plugin gets both on disk — duplicate UI entries, no hard error. Migration is a
+  documented `rm -rf` of the old dir. The backward-compat gate is about *not breaking* npx users, not
+  about preventing dual-install.
+- **Overlays have no native plugin slot.** Plugins ship commands/agents/hooks/skills — not arbitrary
+  context files like `shared.md`. The team-layer ADR names #57 as "the explicit seam where plugin
+  distribution attaches," but *how* overlay content rides in a plugin is unsolved (skill? SessionStart
+  hook that composes? documented copy?). This is the harder half of #57.
+- **Obsolescence discipline applies.** Per the roadmap, anything VINE builds near the platform's orbit
+  gets a 3–6 month config review. A plugin manifest is close to the platform — keep it thin.
+
+### Tech Debt in Affected Areas
+
+- **Version drift, pre-existing.** package.json is `0.3.0` while CHANGELOG `[Unreleased]` is the 0.4.0
+  cycle. The plugin adds a *third* version source (plugin.json + marketplace entry) — version-sync is
+  now a release-checklist concern, called out in #57's acceptance criteria.
+- **`commands/vine/` nesting vs. flat plugin discovery** — may force a layout decision or a build/copy
+  step; flagged as a fork, not yet debt to pay.
+- **Unverified platform claim (do not act on yet):** the guide flagged flat `commands/*.md` as
+  "deprecated for new plugins, use `skills/`". Treat as **unverified** per shared.md's agent-diagnosis
+  rule — re-confirm against docs in inquire before any migration. If true it's a large fork; if false,
+  commands ship as-is.
+
+### Documentation Gaps
+
+- **README install section** ([README.md](README.md) ~line 115) documents npx + manual-copy only.
+  #57's acceptance criteria require documenting plugin install as the *recommended* path, npx as the
+  alternative.
+- **Release checklist** (in `.vine/context/shared.md` CI/CD section and any CONTRIBUTING notes) must
+  gain the plugin/marketplace version-sync step.
+- **CHANGELOG** needs a 0.4.0 plugin entry; the `[Unreleased]` block is the current home.
+- **Solo→team graduation path** (README, per team-layer ADR) should point at the plugin as the
+  cross-repo overlay-distribution mechanism once it exists.
+
+### Open Questions
+
+1. **Repo layout** — Plugin at repo root (reusing `commands/`, `agents/`), a `plugins/vine/` subdir,
+   or a restructure? Does plugin discovery handle the nested `commands/vine/*.md`, or must the layout
+   flatten? Resolve before any manifest is written.
+2. **Commands vs. skills** — Verify the "flat commands deprecated, use skills/" claim against current
+   docs. Decide whether the 11 commands ship as `commands/` (status quo) or migrate to `skills/`.
+   Highest-leverage fork — changes the size of the cycle.
+3. **Overlay distribution mechanism** — How does team/company `shared.md` overlay content travel
+   inside a plugin (no native overlay component exists)? This is the expanded-scope core of #57 and
+   the team-layer ADR's named seam. Candidate mechanisms to weigh in inquire: a skill that installs
+   overlay content, a SessionStart hook, or documented file placement + init recompose.
+4. **Hook home** — Does `journal-check.sh` move to the plugin's `hooks/hooks.json`
+   (`${CLAUDE_PLUGIN_ROOT}`), stay an npx scaffold copy, or both? Affects the npx installer's role.
+5. **npx coexistence policy** — What does init/README tell dual-install users? Is there an init-time
+   detection + cleanup offer (the #58 rename-fallback pattern: offer migration, declining changes
+   nothing)?
+6. **Version-sync mechanism** — One source of truth across package.json, plugin.json, and the
+   marketplace entry, or a sync step in the release checklist? Pin vs. git-SHA float.
+7. **Marketplace hosting** — This repo's own `marketplace.json`, and the `source` form for the plugin
+   entry (relative path vs. github source vs. git-subdir).

--- a/.vine/projects/workflow/plugin-packaging/NAVIGATION.md
+++ b/.vine/projects/workflow/plugin-packaging/NAVIGATION.md
@@ -10,7 +10,7 @@
 
 ### Slice 1: Plugin manifest, marketplace, and invocation spike — Complete
 **Started**: 2026-06-23 00:13
-**Commit**: pending
+**Commit**: 0d53055
 **Gear**: walk-me-through
 **Approach taken**: Stood up `.claude-plugin/plugin.json` (name `vine`, version `0.4.0`) and
 `.claude-plugin/marketplace.json` (marketplace name `moduloMoments`, one plugin entry `vine`,

--- a/.vine/projects/workflow/plugin-packaging/NAVIGATION.md
+++ b/.vine/projects/workflow/plugin-packaging/NAVIGATION.md
@@ -1,0 +1,81 @@
+# Navigation Journal: Claude Code Plugin Packaging
+
+## Feature: .vine/projects/workflow/plugin-packaging
+## Branch: feature/plugin-packaging
+## Started: 2026-06-23
+
+---
+
+## Phase 1: Scaffold + Invocation Proof
+
+### Slice 1: Plugin manifest, marketplace, and invocation spike — Complete
+**Started**: 2026-06-23 00:13
+**Commit**: pending
+**Gear**: walk-me-through
+**Approach taken**: Stood up `.claude-plugin/plugin.json` (name `vine`, version `0.4.0`) and
+`.claude-plugin/marketplace.json` (marketplace name `moduloMoments`, one plugin entry `vine`,
+`source: "./"`). Converted `commands/vine/status.md` → `skills/status/SKILL.md` verbatim body,
+revised frontmatter. Validated manifests with `claude plugin validate .` (pass), installed at
+**local scope** (`claude plugin marketplace add ./ --scope local` + `claude plugin install
+vine@moduloMoments --scope local`), and confirmed the installed snapshot carries the skill + all 4
+agents and resolves version 0.4.0 from plugin.json.
+
+Before writing, researched the exact plugin/skill schema two ways: (1) claude-code-guide agent
+against current docs, (2) the installed GSD framework as a real-world commands→skills reference.
+GSD inspection corrected a guide-agent claim (see Learnings) and shaped the frontmatter decision.
+
+**Deviations from spec**:
+  - SPEC Slice 1 said map frontmatter `name/description/argument-hint/allowed-tools`. We **omit
+    `name`** instead — for a plugin skill at `skills/status/`, the `/vine:` namespace derives from
+    plugin name + dir name, and an explicit `name: vine:status` risks double-namespacing. Kept
+    `argument-hint` + `allowed-tools` (GSD evidence shows both are tolerated), added the spec'd
+    `disable-model-invocation: true`. SPEC.md annotated.
+  - SPEC said marketplace `source = github tracking the default branch, no ref`. For a plugin in
+    the **same repo** as the marketplace, the correct schema is the relative `source: "./"` (a
+    github-source object is for a plugin in a *different* repo). Same intent achieved: a user who
+    runs `claude plugin marketplace add moduloMoments/VINE` clones the default branch (`main`) and
+    resolves `"./"` within it — zero ref/sha management, no `version` in the entry (plugin.json
+    wins). SPEC.md annotated.
+**Validation**: pass — manifests pass `claude plugin validate .`; local install succeeds and
+version 0.4.0 resolves; skill + 4 agents present in snapshot. **Colon-form gate confirmed by the
+engineer** in an authenticated session: `/vine:status` resolves in COLON form (the worktree showed
+two identical `vine:status` entries — the legacy command symlink + the new plugin skill — proving
+the plugin's skill is colon, not hyphen; a hyphen failure would have read `vine-status`). The
+duplicate is the documented "coexistence duplicates, doesn't collide" and clears in Slice 5 when the
+command tree + symlink are removed. No-auto-fire holds (skill only appeared on explicit invocation;
+`disable-model-invocation: true` set).
+**Decisions made during implementation**:
+  - Keep `argument-hint` + `allowed-tools` in SKILL.md; omit `name`: rationale above (decided by: engineer) [confidence: high]
+  - Marketplace name `moduloMoments`, plugin name `vine` → install `vine@moduloMoments`: publisher-as-marketplace convention; plugin name locked to `vine` for the namespace (decided by: claude) [confidence: medium]
+  - Verify via local-scope install (not global): isolates to this worktree's gitignored settings.local.json, reversible (decided by: claude) [confidence: high]
+  - **Conversion recipe = verbatim body, frontmatter-only changes** (sets Slice 2 pattern): grounded in the canonical skill-creator guide — for `disable-model-invocation` skills the description-triggering pillar is moot, and VINE already does the progressive-disclosure pillar (commands point to STATE.md / shared.md). `<objective>` is GSD house style (all 64 of its `<objective>` skills auto-invoke; 0 disable it), not a canonical requirement. Restructuring would be cosmetic and would violate AC-1 "behavior identical" (decided by: engineer) [confidence: high]
+**Acceptance criteria**:
+  - [x] AC1 invocation colon form `/vine:status` — confirmed by engineer (two identical `vine:status` entries, not `vine-status`)
+  - [x] AC2 no auto-fire — `disable-model-invocation: true` set; skill only ran on explicit invocation
+  - [x] AC3 argument preserved — `$ARGUMENTS` carried over (frontmatter `argument-hint` retained)
+  - [x] AC4 4 agents load via plugin — present in installed snapshot
+**Engineer feedback incorporated**: Chose to keep both frontmatter fields after I surfaced GSD
+evidence that disproved the "skills ignore allowed-tools" premise.
+**Learnings**:
+  - Engineer → Claude: Asked me to check how GSD handled the same commands→skills migration —
+    GSD is the on-disk reference that corrected the docs-agent claim.
+  - Claude → Engineer: (1) The claude-code-guide agent's "skills don't honor `allowed-tools`" was
+    empirically false — 66/68 installed GSD skills carry it. Agent-diagnosis-unverified discipline
+    paid off. (2) GSD installs as flat prefixed skills (`/gsd-help`, hyphen) — the colon form is a
+    *plugin-namespace* property, not a `name`-field property; copying GSD's `name:` habit is the one
+    thing that could break VINE's colon form. (3) A `directory`-source install is a snapshot copy
+    into `~/.claude/plugins/cache/.../0.4.0/`; the dev loop is edit → `claude plugin marketplace
+    update moduloMoments` (or `/reload-plugins`) to pick up changes.
+
+### Discovered Items (not in scope — for evolve/triage)
+  - **Whole-repo plugin payload**: `source: "./"` ships the *entire repo* in the plugin cache
+    (commands/, .vine/, README, package.json, ROADMAP, …). Slice 5 removes commands//package.json/bin,
+    but `.vine/`, `references/`, agents/, docs still ship. Consider a plugin file-allowlist /
+    `.claudeignore` to slim the user-facing payload. Candidate backlog item.
+  - **Automated invocation testing is blocked by auth**: nested `claude -p --plugin-dir … "/vine:…"`
+    returns 401 (no inherited session credentials), so the colon-form gate can't be CI-automated this
+    way. Relevant if a future cycle wants automated plugin smoke tests.
+  - **Oversized skill bodies** (`init` ~38KB, `evolve` ~32KB, `navigate` ~30KB) exceed the skill-creator
+    <500-line "ideal." Not a conversion blocker (kept verbatim per recipe decision), but a candidate
+    trim — overlaps the existing optimize-scope per-phase context-trim backlog item. Route there, not
+    into this packaging cycle.

--- a/.vine/projects/workflow/plugin-packaging/PROJECT-MAP.md
+++ b/.vine/projects/workflow/plugin-packaging/PROJECT-MAP.md
@@ -8,7 +8,7 @@
 |-------|--------|---------|
 | verify | ✅ | 2026-06-22 |
 | inquire | ✅ | 2026-06-22 |
-| navigate | ⬜ | — |
+| navigate | 🚧 | 2026-06-23 |
 | evolve | ⬜ | — |
 
 ### Milestones

--- a/.vine/projects/workflow/plugin-packaging/PROJECT-MAP.md
+++ b/.vine/projects/workflow/plugin-packaging/PROJECT-MAP.md
@@ -15,7 +15,7 @@
 
 | Phase | Slices | Status | PR |
 |-------|--------|--------|----|
-| Phase 1: Scaffold + Invocation Proof | Slice 1 | ⬜ Pending | — |
-| Phase 2: Convert the Product to Skills | Slices 2–3 | ⬜ Pending | — |
+| Phase 1: Scaffold + Invocation Proof | Slice 1 | ✅ Complete | — |
+| Phase 2: Convert the Product to Skills | Slices 2–3 | 🚧 Active | — |
 | Phase 3: Remove npx + Rewire Tooling | Slices 4–6 | ⬜ Pending | — |
 | Phase 4: Docs + Cycle Knowledge | Slices 7–9 | ⬜ Pending | — |

--- a/.vine/projects/workflow/plugin-packaging/PROJECT-MAP.md
+++ b/.vine/projects/workflow/plugin-packaging/PROJECT-MAP.md
@@ -15,7 +15,7 @@
 
 | Phase | Slices | Status | PR |
 |-------|--------|--------|----|
-| Phase 1: Scaffold + Invocation Proof | Slice 1 | ✅ Complete | — |
+| Phase 1: Scaffold + Invocation Proof | Slice 1 | ✅ Shipped | #134 |
 | Phase 2: Convert the Product to Skills | Slices 2–3 | 🚧 Active | — |
 | Phase 3: Remove npx + Rewire Tooling | Slices 4–6 | ⬜ Pending | — |
 | Phase 4: Docs + Cycle Knowledge | Slices 7–9 | ⬜ Pending | — |

--- a/.vine/projects/workflow/plugin-packaging/PROJECT-MAP.md
+++ b/.vine/projects/workflow/plugin-packaging/PROJECT-MAP.md
@@ -7,6 +7,15 @@
 | Phase | Status | Updated |
 |-------|--------|---------|
 | verify | ✅ | 2026-06-22 |
-| inquire | ⬜ | — |
+| inquire | ✅ | 2026-06-22 |
 | navigate | ⬜ | — |
 | evolve | ⬜ | — |
+
+### Milestones
+
+| Phase | Slices | Status | PR |
+|-------|--------|--------|----|
+| Phase 1: Scaffold + Invocation Proof | Slice 1 | ⬜ Pending | — |
+| Phase 2: Convert the Product to Skills | Slices 2–3 | ⬜ Pending | — |
+| Phase 3: Remove npx + Rewire Tooling | Slices 4–6 | ⬜ Pending | — |
+| Phase 4: Docs + Cycle Knowledge | Slices 7–9 | ⬜ Pending | — |

--- a/.vine/projects/workflow/plugin-packaging/PROJECT-MAP.md
+++ b/.vine/projects/workflow/plugin-packaging/PROJECT-MAP.md
@@ -1,0 +1,12 @@
+# Project Map: Claude Code Plugin Packaging + Team-Overlay Distribution
+## Feature: .vine/projects/workflow/plugin-packaging
+## Created: 2026-06-22
+
+### VINE Progress
+
+| Phase | Status | Updated |
+|-------|--------|---------|
+| verify | ✅ | 2026-06-22 |
+| inquire | ⬜ | — |
+| navigate | ⬜ | — |
+| evolve | ⬜ | — |

--- a/.vine/projects/workflow/plugin-packaging/SPEC.md
+++ b/.vine/projects/workflow/plugin-packaging/SPEC.md
@@ -46,9 +46,24 @@ dogfooding, and the npm publish flow are removed.
 - **Hook home = plugin** — journal-check wires natively via `hooks/hooks.json` using
   `${CLAUDE_PLUGIN_ROOT}`. Contributor-only hooks (`trellis-gate.sh`, `main-guard.sh`) stay unshipped,
   wired by the repo's own `.claude/settings.json` as today.
-- **Version** — with npm gone, `plugin.json` `version` becomes the single version source; bump to
-  `0.4.0` (clearing the pre-existing package.json drift). The marketplace entry omits `version`
-  (plugin.json wins silently).
+- **Versioning & release** — with npm gone, the version strategy follows from one platform fact:
+  Claude Code resolves a plugin's version as `plugin.json version` → marketplace `version` → git SHA,
+  and **a set `version` gates updates** (users move only when the *string* changes; an omitted version
+  floats on every commit). Because our plugin source repo *is* the contributor tree, floating would
+  ship WIP to users — so we **pin**:
+  - `plugin.json` `version` (SemVer) is the **single source of truth**; bump to `0.4.0`. The
+    marketplace entry omits `version` (plugin.json wins silently). `package.json` is removed entirely
+    (Slice 5) so no competing version field survives.
+  - **SemVer policy** (no API — only command behavior): **major** = a command/skill removed/renamed or
+    an invocation/artifact-contract break; **minor** = new command/skill/agent/hook or capability;
+    **patch** = prose/doc/non-behavioral fixes.
+  - **Users update** via `/plugin update vine` (or auto-update) — replaces `npx create-vine@latest`.
+  - **Branch model: `main` = release, `develop` = integration.** `main` holds only released states, so
+    the marketplace `source` tracks `main` (the default branch) with **zero ref/sha management** and
+    every released version is reproducible. All development (including this cycle's remaining PRs)
+    targets `develop`; cutting a release = merge `develop`→`main`, bump `plugin.json` version, tag
+    `vX.Y.Z`, GitHub release. The existing main-guard hook ("don't commit directly to main") already
+    fits this model.
 - **Contributor dogfooding moves to local plugin install** — the old `.claude/commands/vine/` symlink
   is removed; contributors load the repo as a plugin (`claude plugin marketplace add .`). The dev loop
   (how a skill edit is picked up) is established and documented in Slice 1.
@@ -80,8 +95,12 @@ dogfooding, and the npm publish flow are removed.
 9. **Docs current.** README leads with plugin install; CLAUDE.md, `shared.md`, `references/STATE.md`,
    and CHANGELOG describe the skills/plugin product; the solo→team graduation path documents overlays
    as consumer-owned with no VINE distribution mechanism.
-10. **Decisions recorded.** Knowledge ADR(s) capture the drop-npx decision (revised gate) and the
-    overlay-is-consumer-owned decision (amending the team-layer ADR's "seam" expectation).
+10. **Decisions recorded.** Knowledge ADR(s) capture the drop-npx decision (revised gate), the
+    overlay-is-consumer-owned decision (amending the team-layer ADR's "seam" expectation), and the
+    versioning + `main`-release/`develop`-integration branch model.
+11. **Versioning coherent.** `plugin.json` `version` is the sole version source (`0.4.0`); no
+    `package.json` version competes; marketplace `source` tracks `main` with no `ref`; `main` holds
+    only released states; the documented user-update path is `/plugin update vine`.
 
 ### Work Slices
 
@@ -93,7 +112,9 @@ recipe is proven and the colon-form risk is retired. Ships as PR 1.
 
 ### Slice 1: Plugin manifest, marketplace, and invocation spike
 - **Goal**: Stand up `.claude-plugin/plugin.json` (name `vine`, version `0.4.0`) and
-  `.claude-plugin/marketplace.json` (one entry, `source` = repo root). Convert one low-risk command
+  `.claude-plugin/marketplace.json` (one entry; `source` = github tracking the default branch, **no
+  `ref`** — per the branch model, `main` holds only releases; omit `version` so plugin.json wins).
+  Convert one low-risk command
   (`status`) to `skills/status/SKILL.md` with `disable-model-invocation: true`, mapping frontmatter
   (`name`/`description`/`argument-hint`/`allowed-tools`) and confirming `$ARGUMENTS` carries over.
   Install the plugin locally (`claude plugin marketplace add .` + install) and verify end-to-end.
@@ -150,18 +171,23 @@ have a migration path. Ships as PR 3.
   malformed SKILL.md; the gate blocks a commit touching `skills/` without a green trellis run (AC 8).
 - **Complexity signal**: Medium — trellis encodes the old layout in multiple checks; each must move.
 
-### Slice 5: Remove the npx distribution
-- **Goal**: Delete `bin/cli.js`, the migrated `commands/vine/` tree, and the `.claude/commands/vine/`
-  symlink; update `package.json` (drop `bin`/`create-vine` packaging and the commands entries from
-  `files`; keep only what repo metadata needs); replace `publish.yml`'s npm publish with a git-tag +
-  GitHub-release flow (the marketplace installs from git).
+### Slice 5: Remove the npx distribution + rework the release flow
+- **Goal**: Delete `bin/cli.js`, the migrated `commands/vine/` tree, the `.claude/commands/vine/`
+  symlink, and **`package.json` entirely** (nothing functional needs it post-npm — the only
+  references are the deleted `bin/cli.js` and prose examples). Rework `.github/workflows/publish.yml`:
+  read the version from `plugin.json`, drop the `npm publish` + node smoke-test steps (replace the
+  smoke test with a plugin-load / `trellis-check` validation), keep the tag-exists-check +
+  CHANGELOG-extract + GitHub-release steps. Adopt the branch model: create `develop`, set it as the
+  PR base for ongoing work, leave `main` as the release branch the marketplace tracks.
 - **Depends on**: Slices 2–4 (skills + tooling must be live before the old path is removed).
 - **Files likely touched**: `bin/cli.js` (delete), `commands/vine/` (delete), `.claude/commands/vine/`
-  symlink (delete), `package.json`, `.github/workflows/publish.yml`.
-- **Acceptance criteria**: No `create-vine`/npm artifacts remain; the release flow tags + releases for
-  the marketplace; contributor dogfooding via local plugin install works (AC 6–8).
+  symlink (delete), `package.json` (delete), `.github/workflows/publish.yml`.
+- **Acceptance criteria**: No `create-vine`/npm artifacts or competing version source remain; the
+  release workflow tags + creates a GitHub release sourced from `plugin.json` version with no npm step;
+  contributor dogfooding via local plugin install works (AC 6–8, 11).
 - **Complexity signal**: Medium — deletion is easy; reworking `publish.yml` and confirming nothing
-  else references the removed paths is the care point.
+  else references the removed paths (grep for `package.json` / `create-vine` / `commands/vine`) is the
+  care point.
 
 ### Slice 6: init legacy-install migration
 - **Goal**: `/vine:init` detects a legacy `.claude/commands/vine/` (old npx install) and offers a
@@ -178,8 +204,9 @@ decisions.
 Session boundary: Docs and knowledge are current; #57 is closeable. Ships as PR 4.
 
 ### Slice 7: README + CHANGELOG
-- **Goal**: Lead the README with plugin install (`claude plugin marketplace add` → install); remove
-  the npx/manual-copy sections; add a migration note for existing npx users; document the solo→team
+- **Goal**: Lead the README with plugin install (`claude plugin marketplace add` → install) and the
+  update path (`/plugin update vine`, replacing `npx create-vine@latest`); remove the npx/manual-copy
+  sections; add a migration note for existing npx users; document the solo→team
   graduation path (fork the plugin's skills/agents; overlays stay repo-local and consumer-authored —
   no VINE distribution mechanism). Add the 0.4.0 CHANGELOG entry. Note journal-check's default-on
   change for plugin users.
@@ -193,31 +220,39 @@ Session boundary: Docs and knowledge are current; #57 is closeable. Ships as PR 
 ### Slice 8: Internal docs (CLAUDE.md, shared.md, STATE.md)
 - **Goal**: Rewrite CLAUDE.md "What This Repo Is" / Repository Structure / Command Authoring
   Conventions for the skills/plugin product; rename shared.md's "Command Addition Checklist" →
-  "Skill Addition Checklist" and update the Skill Workflows install step; update `references/STATE.md`
-  product references and add the version-sync note (plugin.json single source).
+  "Skill Addition Checklist" and update the Skill Workflows install step; rewrite shared.md's CI/CD
+  **Release checklist** for the new flow (bump `plugin.json` version per SemVer → CHANGELOG → merge
+  `develop`→`main` → tag `vX.Y.Z` → GitHub release; no npm) and record the SemVer policy + the
+  `main`-release/`develop`-integration branch model + the Branch Naming convention (feature branches
+  now off `develop`); update `references/STATE.md` product references and the version note
+  (`plugin.json` single source).
 - **Depends on**: Slices 1–6.
-- **Files likely touched**: `CLAUDE.md`, `.vine/context/shared.md`, `.vine/context/verify.md` (command
-  count), `references/STATE.md`.
+- **Files likely touched**: `CLAUDE.md`, `.vine/context/shared.md` (CI/CD Release checklist, Branch
+  Naming, Skill Addition Checklist, Skill Workflows), `.vine/context/verify.md` (command count),
+  `references/STATE.md`.
 - **Acceptance criteria**: No internal doc describes the product as "11 command files in
-  `commands/vine/`" or references the npx-only install; the addition checklist targets skills (AC 9).
+  `commands/vine/`" or references the npx-only install; the addition checklist targets skills; the
+  release checklist and branch model are documented (AC 9, 11).
 - **Complexity signal**: Medium — the old layout is referenced across several contributor docs; the
   Command/State Addition checklists in shared.md exist to catch exactly this kind of multi-file drift.
 
 ### Slice 9: Knowledge ADR(s)
-- **Goal**: Record (a) the plugin-only / drop-npx decision and its rationale (revised hard gate), and
+- **Goal**: Record (a) the plugin-only / drop-npx decision and its rationale (revised hard gate),
   (b) overlay distribution = document-only / consumer-owned, amending the team-layer ADR's "seam"
-  expectation.
+  expectation, and (c) the versioning strategy + `main`-release/`develop`-integration branch model
+  (plugin.json as version gate; pin-not-float because the repo is the dev tree).
 - **Depends on**: Slices 1–8 (decisions are settled by the work).
-- **Files likely touched**: `.vine/knowledge/workflow/2026-06-*-*.md` (1–2 ADRs).
+- **Files likely touched**: `.vine/knowledge/workflow/2026-06-*-*.md` (2–3 ADRs).
 - **Acceptance criteria**: ADRs exist in the committed knowledge format; the team-layer "seam"
-  expectation is explicitly amended rather than left dangling (AC 10).
+  expectation is explicitly amended rather than left dangling; the versioning/branch-model decision is
+  captured (AC 10).
 - **Complexity signal**: Low — durable-decision capture in the established ADR format.
 
 ### Tech Debt Integration
 
 - **Version drift (package.json 0.3.0 vs 0.4.0 CHANGELOG)** — *Addressed now.* `plugin.json` becomes
-  the single version source at `0.4.0`; package.json's npm version stops mattering once npm publish is
-  removed (Slice 5).
+  the single version source at `0.4.0`; `package.json` is removed entirely (Slice 5), eliminating the
+  competing version field rather than just neutralizing it.
 - **`commands/vine/` nesting vs. flat plugin discovery** — *Resolved by design.* The skills layout
   sidesteps it entirely; no nested-command discovery is relied on.
 - **Unverified "flat commands deprecated, use skills/" claim** — *Resolved.* Verified against current
@@ -242,6 +277,11 @@ Session boundary: Docs and knowledge are current; #57 is closeable. Ships as PR 
   checklists in shared.md.
 - **Dependency — Claude Code plugin/marketplace feature.** GA per current docs; no preview flag
   needed.
+- **Process change — branch model adoption.** `develop` must exist and become the PR base before
+  Phase 1's PR merges; `main` is reserved for releases the marketplace tracks. This is repo-admin
+  (branch creation + default-PR-base/branch-protection settings) plus doc updates — light, but it
+  retargets this cycle's remaining PRs to `develop`, so the navigator should branch from and PR into
+  `develop`, not `main`.
 
 ### Backlog Updates
 

--- a/.vine/projects/workflow/plugin-packaging/SPEC.md
+++ b/.vine/projects/workflow/plugin-packaging/SPEC.md
@@ -104,7 +104,7 @@ dogfooding, and the npm publish flow are removed.
 
 ### Work Slices
 
-## Phase 1: Scaffold + Invocation Proof (Slices 1) ⬜
+## Phase 1: Scaffold + Invocation Proof (Slices 1) ✅
 Summary: Add the plugin manifest + marketplace and prove the skill recipe and colon namespace on a
 single low-risk command before converting anything else.
 Session boundary: The plugin installs locally and one phase invokes as `/vine:status`; the conversion

--- a/.vine/projects/workflow/plugin-packaging/SPEC.md
+++ b/.vine/projects/workflow/plugin-packaging/SPEC.md
@@ -117,6 +117,19 @@ recipe is proven and the colon-form risk is retired. Ships as PR 1.
   Convert one low-risk command
   (`status`) to `skills/status/SKILL.md` with `disable-model-invocation: true`, mapping frontmatter
   (`name`/`description`/`argument-hint`/`allowed-tools`) and confirming `$ARGUMENTS` carries over.
+
+  > **Addendum (navigate, 2026-06-23):** Two schema realities differed from the above and were
+  > applied during implementation:
+  > - **Marketplace `source` = relative `"./"`, not a github-source object.** For a plugin living in
+  >   the *same repo* as the marketplace, the documented form is the relative path `"./"`; a
+  >   github-source object is for a plugin in a *different* repo. The intent is unchanged — adding
+  >   the github repo tracks its default branch (`main`) with no `ref`, and the entry omits
+  >   `version` so plugin.json wins. (`marketplace.json` also requires `owner` and a
+  >   `metadata.description` to validate cleanly.)
+  > - **Frontmatter: `name` is omitted, not mapped.** The `/vine:status` colon form derives from
+  >   plugin name (`vine`) + skill dir (`status`); an explicit `name: vine:status` risks
+  >   double-namespacing. `argument-hint` + `allowed-tools` are kept (empirically tolerated — 66/68
+  >   installed GSD skills carry `allowed-tools`), and `disable-model-invocation: true` is added.
   Install the plugin locally (`claude plugin marketplace add .` + install) and verify end-to-end.
 - **Depends on**: Nothing.
 - **Files likely touched**: `.claude-plugin/plugin.json` (new), `.claude-plugin/marketplace.json`

--- a/.vine/projects/workflow/plugin-packaging/SPEC.md
+++ b/.vine/projects/workflow/plugin-packaging/SPEC.md
@@ -1,0 +1,251 @@
+# Feature Spec: Claude Code Plugin Packaging (skills-only, drop npx)
+## Date: 2026-06-22
+## Built on: CONTEXT.md (2026-06-22)
+## Decisions made by: Rob
+
+### Problem Statement
+
+VINE ships today as 11 `commands/vine/*.md` files installed by the `create-vine` npx tool (file-copy
+into `.claude/commands/vine/`). Cycle 5 of v0.4.0 ([#57](https://github.com/moduloMoments/VINE/issues/57))
+repackages VINE as a **native Claude Code plugin** distributed via a self-hosted marketplace.
+
+The verify phase confirmed the platform schema and surfaced one load-bearing fork (commands vs.
+skills). Resolving it reshaped the cycle from "package the existing commands" into a clean migration:
+
+- **Skills become the sole product.** Docs steer new plugins to `skills/`, and a plugin named `vine`
+  with `skills/<name>/SKILL.md` resolves to the exact colon form `/vine:<name>` — so invocation is
+  unchanged. (Flat `commands/` in a plugin can't be made to namespace from a non-plugin install, and
+  nested `commands/vine/*.md` is undocumented.)
+- **npx is retired.** Rather than carry two distribution surfaces forever, the npx path is dropped
+  this cycle. This **revises #57's stated hard gate** from "keep npx working" to "migrate npx users to
+  the plugin" — a deliberate roadmap call given the early, small installed base.
+- **Overlay distribution is documentation, not a mechanism.** Overlay *content* is 100%
+  consumer-owned. Plugins have no native slot for delivering an arbitrary context file, and a company
+  wanting cross-repo conventions can fork the plugin's skills/agents (which distribute natively),
+  leaving `.vine/context/shared.md` repo-local and consumer-authored. VINE ships no overlay-delivery
+  feature — only docs and a decision record. This is the "harder half" of #57, resolved by scoping it
+  out.
+
+### Approach
+
+**End state:** one product representation (`skills/<name>/SKILL.md` at repo root) distributed as a
+native plugin (`.claude-plugin/plugin.json` + self-hosted `.claude-plugin/marketplace.json`), with
+agents and the journal-check hook riding in the same plugin. The npx installer, its symlink-based
+dogfooding, and the npm publish flow are removed.
+
+**Key decisions and rationale:**
+
+- **Skills, not commands** — the only layout that guarantees `/vine:<name>` from the docs (plugin name
+  `vine` + skill dir name → `/vine:<name>`, colon form confirmed in the plugins reference). Slice 1
+  validates this empirically before any mass conversion; a hyphen form is a stop-and-flag.
+- **`disable-model-invocation: true` on every skill** — VINE phases are deliberate, user-driven gates.
+  The model must never auto-fire `/vine:navigate`. Every converted SKILL.md carries the flag.
+- **Drop npx now, no transition window** — single distribution path, no sync surface, no two-tree
+  drift. Existing npx users migrate via documented cleanup (init offers to remove a legacy
+  `.claude/commands/vine/` install; declining is a no-op — the #58 offer-migration pattern).
+- **Hook home = plugin** — journal-check wires natively via `hooks/hooks.json` using
+  `${CLAUDE_PLUGIN_ROOT}`. Contributor-only hooks (`trellis-gate.sh`, `main-guard.sh`) stay unshipped,
+  wired by the repo's own `.claude/settings.json` as today.
+- **Version** — with npm gone, `plugin.json` `version` becomes the single version source; bump to
+  `0.4.0` (clearing the pre-existing package.json drift). The marketplace entry omits `version`
+  (plugin.json wins silently).
+- **Contributor dogfooding moves to local plugin install** — the old `.claude/commands/vine/` symlink
+  is removed; contributors load the repo as a plugin (`claude plugin marketplace add .`). The dev loop
+  (how a skill edit is picked up) is established and documented in Slice 1.
+
+**Sequencing principle:** de-risk first (prove the namespace + recipe on one skill), convert in bulk,
+*then* remove the old path — so the repo stays functional at every phase boundary.
+
+### Acceptance Criteria
+
+1. **Invocation unchanged.** All 11 phases invoke as `/vine:<name>` (colon form) under a plugin
+   install, with behavior identical to today — empirically verified by installing the plugin locally,
+   not inferred. A hyphen form (`/vine-navigate`) halts the cycle for redesign.
+2. **No auto-fire.** Every `skills/<name>/SKILL.md` contains `disable-model-invocation: true`; no VINE
+   phase triggers from model reasoning.
+3. **Arguments preserved.** `argument-hint` and `$ARGUMENTS` (and positional forms) behave in skills
+   as they did in commands (e.g. `/vine:inquire workflow/foo` passes the slug through).
+4. **Agents intact.** The 4 agents (`agents/*.md`) load and auto-delegate via the plugin, unchanged.
+5. **Hook native.** journal-check fires on a real navigate session loaded via the plugin, wired
+   through `hooks/hooks.json` + `${CLAUDE_PLUGIN_ROOT}`; `trellis-gate.sh` / `main-guard.sh` remain
+   unshipped.
+6. **Marketplace install works.** `claude plugin marketplace add <repo>` then install brings the full
+   product (11 skills + 4 agents + hook), documented as the install path.
+7. **npx removed cleanly.** `bin/cli.js`, `commands/vine/`, and the `.claude/commands/vine/` symlink
+   are gone; `package.json` no longer declares the `create-vine` bin/npm packaging; `publish.yml` no
+   longer publishes to npm. Existing-user migration is documented and init offers legacy-install
+   cleanup (declining changes nothing).
+8. **Tooling rewired.** `/trellis` and `trellis-gate.sh` validate/watch the `skills/<name>/SKILL.md`
+   layout; contributor dogfooding via local plugin install is documented and works.
+9. **Docs current.** README leads with plugin install; CLAUDE.md, `shared.md`, `references/STATE.md`,
+   and CHANGELOG describe the skills/plugin product; the solo→team graduation path documents overlays
+   as consumer-owned with no VINE distribution mechanism.
+10. **Decisions recorded.** Knowledge ADR(s) capture the drop-npx decision (revised gate) and the
+    overlay-is-consumer-owned decision (amending the team-layer ADR's "seam" expectation).
+
+### Work Slices
+
+## Phase 1: Scaffold + Invocation Proof (Slices 1) ⬜
+Summary: Add the plugin manifest + marketplace and prove the skill recipe and colon namespace on a
+single low-risk command before converting anything else.
+Session boundary: The plugin installs locally and one phase invokes as `/vine:status`; the conversion
+recipe is proven and the colon-form risk is retired. Ships as PR 1.
+
+### Slice 1: Plugin manifest, marketplace, and invocation spike
+- **Goal**: Stand up `.claude-plugin/plugin.json` (name `vine`, version `0.4.0`) and
+  `.claude-plugin/marketplace.json` (one entry, `source` = repo root). Convert one low-risk command
+  (`status`) to `skills/status/SKILL.md` with `disable-model-invocation: true`, mapping frontmatter
+  (`name`/`description`/`argument-hint`/`allowed-tools`) and confirming `$ARGUMENTS` carries over.
+  Install the plugin locally (`claude plugin marketplace add .` + install) and verify end-to-end.
+- **Depends on**: Nothing.
+- **Files likely touched**: `.claude-plugin/plugin.json` (new), `.claude-plugin/marketplace.json`
+  (new), `skills/status/SKILL.md` (new), `commands/vine/status.md` (left in place this phase).
+- **Acceptance criteria**: `/vine:status` resolves in **colon** form, runs, accepts its argument, and
+  does **not** auto-fire (AC 1–3). The 4 agents still load via the plugin (AC 4). **Stop-and-flag** if
+  the invocation is hyphenated or any frontmatter field is incompatible. Document the contributor dev
+  loop (how a skill edit is picked up: reinstall/reload).
+- **Complexity signal**: Medium — mechanically small, but this is the de-risking spike the whole
+  cycle rests on; the validation, not the code, is the work.
+
+## Phase 2: Convert the Product to Skills (Slices 2–3) ⬜
+Summary: Apply the proven recipe to the remaining 10 commands and move the journal hook into the
+plugin.
+Session boundary: The full product (11 skills + 4 agents + hook) runs via the plugin. Ships as PR 2.
+
+### Slice 2: Convert the remaining 10 commands to skills
+- **Goal**: Convert init, verify, inquire, navigate, evolve, pair, pause, resume, help, optimize to
+  `skills/<name>/SKILL.md`, each with `disable-model-invocation: true`, using the Slice 1 recipe.
+- **Depends on**: Slice 1.
+- **Files likely touched**: `skills/<name>/SKILL.md` ×10 (new); corresponding `commands/vine/*.md`
+  left in place until Phase 3.
+- **Acceptance criteria**: All 11 phases (the 10 here + `status`) invoke as `/vine:<name>` via the
+  plugin with unchanged behavior and arguments; every SKILL.md carries the flag (AC 1–3).
+- **Complexity signal**: Medium — repetitive but voluminous; each file needs frontmatter mapping and a
+  spot-check that the colon namespace + args hold.
+
+### Slice 3: Ship journal-check as a plugin hook
+- **Goal**: Wire `journal-check.sh` via `hooks/hooks.json` using `${CLAUDE_PLUGIN_ROOT}` so plugin
+  users get it natively. Keep contributor-only hooks unshipped.
+- **Depends on**: Slice 1 (manifest exists).
+- **Files likely touched**: `hooks/hooks.json` (new), `hooks/journal-check.sh` (moved/copied from
+  `.vine/scripts/`), `.claude-plugin/plugin.json` if hook discovery needs a pointer.
+- **Acceptance criteria**: journal-check fires on a real navigate session loaded via the plugin;
+  `trellis-gate.sh` / `main-guard.sh` remain unshipped (AC 5). Note the behavior change: auto-wired is
+  default-on for plugin users (today it's opt-in scaffold) — surface in docs (Slice 7).
+- **Complexity signal**: Low — small JSON wiring; the risk is path resolution under
+  `${CLAUDE_PLUGIN_ROOT}`.
+
+## Phase 3: Remove npx + Rewire Tooling (Slices 4–6) ⬜
+Summary: Retire the npx distribution and point the contributor tooling at the skills layout.
+Session boundary: The old path is gone, contributor dogfooding runs on the plugin, and existing users
+have a migration path. Ships as PR 3.
+
+### Slice 4: Rewire `/trellis` and the trellis-gate to the skills layout
+- **Goal**: Update `/trellis` (`.claude/commands/trellis.md`) to validate `skills/<name>/SKILL.md`
+  (frontmatter, section ordering, the renamed Skill Addition Checklist) instead of `commands/vine/*.md`;
+  update `.vine/scripts/trellis-gate.sh` to watch `skills/`.
+- **Depends on**: Slice 2 (skills exist to validate).
+- **Files likely touched**: `.claude/commands/trellis.md`, `.vine/scripts/trellis-gate.sh`.
+- **Acceptance criteria**: `/trellis` passes against the converted skills and flags a deliberately
+  malformed SKILL.md; the gate blocks a commit touching `skills/` without a green trellis run (AC 8).
+- **Complexity signal**: Medium — trellis encodes the old layout in multiple checks; each must move.
+
+### Slice 5: Remove the npx distribution
+- **Goal**: Delete `bin/cli.js`, the migrated `commands/vine/` tree, and the `.claude/commands/vine/`
+  symlink; update `package.json` (drop `bin`/`create-vine` packaging and the commands entries from
+  `files`; keep only what repo metadata needs); replace `publish.yml`'s npm publish with a git-tag +
+  GitHub-release flow (the marketplace installs from git).
+- **Depends on**: Slices 2–4 (skills + tooling must be live before the old path is removed).
+- **Files likely touched**: `bin/cli.js` (delete), `commands/vine/` (delete), `.claude/commands/vine/`
+  symlink (delete), `package.json`, `.github/workflows/publish.yml`.
+- **Acceptance criteria**: No `create-vine`/npm artifacts remain; the release flow tags + releases for
+  the marketplace; contributor dogfooding via local plugin install works (AC 6–8).
+- **Complexity signal**: Medium — deletion is easy; reworking `publish.yml` and confirming nothing
+  else references the removed paths is the care point.
+
+### Slice 6: init legacy-install migration
+- **Goal**: `/vine:init` detects a legacy `.claude/commands/vine/` (old npx install) and offers a
+  one-time cleanup; declining changes nothing (#58 offer-migration pattern).
+- **Depends on**: Slice 2 (skills are the thing being migrated to).
+- **Files likely touched**: `skills/init/SKILL.md`.
+- **Acceptance criteria**: With a legacy dir present, init offers cleanup and removes it on accept,
+  no-ops on decline; with no legacy dir, init behaves exactly as before (AC 7).
+- **Complexity signal**: Low — additive detection + an AskUserQuestion offer.
+
+## Phase 4: Docs + Cycle Knowledge (Slices 7–9) ⬜
+Summary: Make every doc surface describe the skills/plugin product and record the load-bearing
+decisions.
+Session boundary: Docs and knowledge are current; #57 is closeable. Ships as PR 4.
+
+### Slice 7: README + CHANGELOG
+- **Goal**: Lead the README with plugin install (`claude plugin marketplace add` → install); remove
+  the npx/manual-copy sections; add a migration note for existing npx users; document the solo→team
+  graduation path (fork the plugin's skills/agents; overlays stay repo-local and consumer-authored —
+  no VINE distribution mechanism). Add the 0.4.0 CHANGELOG entry. Note journal-check's default-on
+  change for plugin users.
+- **Depends on**: Slices 1–6 (docs describe the shipped reality).
+- **Files likely touched**: `README.md`, `CHANGELOG.md`.
+- **Acceptance criteria**: README's install path is the plugin; overlay distribution is documented as
+  consumer-owned; no stale npx-as-primary instructions remain (AC 9).
+- **Complexity signal**: Medium — README is the user-facing source of truth; the install/migration
+  narrative must read cleanly for a zero-context reader.
+
+### Slice 8: Internal docs (CLAUDE.md, shared.md, STATE.md)
+- **Goal**: Rewrite CLAUDE.md "What This Repo Is" / Repository Structure / Command Authoring
+  Conventions for the skills/plugin product; rename shared.md's "Command Addition Checklist" →
+  "Skill Addition Checklist" and update the Skill Workflows install step; update `references/STATE.md`
+  product references and add the version-sync note (plugin.json single source).
+- **Depends on**: Slices 1–6.
+- **Files likely touched**: `CLAUDE.md`, `.vine/context/shared.md`, `.vine/context/verify.md` (command
+  count), `references/STATE.md`.
+- **Acceptance criteria**: No internal doc describes the product as "11 command files in
+  `commands/vine/`" or references the npx-only install; the addition checklist targets skills (AC 9).
+- **Complexity signal**: Medium — the old layout is referenced across several contributor docs; the
+  Command/State Addition checklists in shared.md exist to catch exactly this kind of multi-file drift.
+
+### Slice 9: Knowledge ADR(s)
+- **Goal**: Record (a) the plugin-only / drop-npx decision and its rationale (revised hard gate), and
+  (b) overlay distribution = document-only / consumer-owned, amending the team-layer ADR's "seam"
+  expectation.
+- **Depends on**: Slices 1–8 (decisions are settled by the work).
+- **Files likely touched**: `.vine/knowledge/workflow/2026-06-*-*.md` (1–2 ADRs).
+- **Acceptance criteria**: ADRs exist in the committed knowledge format; the team-layer "seam"
+  expectation is explicitly amended rather than left dangling (AC 10).
+- **Complexity signal**: Low — durable-decision capture in the established ADR format.
+
+### Tech Debt Integration
+
+- **Version drift (package.json 0.3.0 vs 0.4.0 CHANGELOG)** — *Addressed now.* `plugin.json` becomes
+  the single version source at `0.4.0`; package.json's npm version stops mattering once npm publish is
+  removed (Slice 5).
+- **`commands/vine/` nesting vs. flat plugin discovery** — *Resolved by design.* The skills layout
+  sidesteps it entirely; no nested-command discovery is relied on.
+- **Unverified "flat commands deprecated, use skills/" claim** — *Resolved.* Verified against current
+  docs in inquire: commands are supported but skills are the forward path; we migrate.
+- **New debt, consciously taken on:**
+  - *Dev-loop friction.* Editing a skill requires a plugin reinstall/reload vs. the old instant
+    symlink edit. Accepted; the loop is documented (Slice 1).
+  - *No npx transition window.* Existing npx users must migrate immediately; mitigated by README
+    migration docs + init's cleanup offer (Slices 6–7).
+
+### Dependencies & Risks
+
+- **Risk — colon vs. hyphen invocation form.** The whole skills choice depends on `/vine:<name>`
+  resolving in colon form. Docs confirm it; Slice 1 verifies empirically and **stops the cycle** if it
+  fails. *Highest-leverage risk, retired first.*
+- **Risk — hook path resolution.** `${CLAUDE_PLUGIN_ROOT}` must resolve journal-check correctly under
+  a plugin load (Slice 3); fail-open behavior in the script limits blast radius.
+- **Risk — stranded npx users.** Mitigated by migration docs + init cleanup offer; acceptable given
+  the small early installed base.
+- **Risk — dangling references after npx removal.** package.json, publish.yml, trellis, and docs all
+  encode the old layout; Slices 4–8 are the systematic sweep, guarded by the Command/State Addition
+  checklists in shared.md.
+- **Dependency — Claude Code plugin/marketplace feature.** GA per current docs; no preview flag
+  needed.
+
+### Backlog Updates
+
+- **Consider a contributor skill-dev helper** (hot-reload or a `make dev` that reinstalls the local
+  plugin) *if* the dev-loop friction proves real after Slice 1 — backlog, low priority.
+- No other additions; the overlay-distribution "feature" is consciously *not* built (documented as
+  consumer-owned), so nothing is parked for it beyond the ADR.

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -1,0 +1,124 @@
+---
+description: "Check feature progress — see which phase you're in, what's done, what's next, and artifact status without loading full session context"
+argument-hint: "[feature path, e.g., 'payments/webhook-support']"
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - AskUserQuestion
+  - TaskList
+---
+
+# vine:status — Quick Progress Check
+
+## Load Context Overlays
+
+Read `.vine/context/shared.md` and `.vine/context/status.md` if they exist, then follow the
+**Overlay Loading Protocol** from `shared.md` for the rest (apply-as-overlay precedence, the
+personal `.local` layer, the legacy-directory fallback, and missing-file behavior). The status
+overlay carries status-specific extensions for this project. If `shared.md` is absent, degrade
+gracefully: read the phase overlay if present, otherwise proceed on command defaults.
+
+## Load Engineer Profile
+
+After loading overlays, resolve the shared personal root (**Resolving the personal root** in
+`shared.md`'s Overlay Loading Protocol) and check for the engineer's profile at
+`<personal-root>/.vine.local/PROFILE.md` — resolved, not cwd-relative, so a worktree session sees
+the same profile as the main checkout.
+
+If it exists, note it for the status display. No depth hint needed — status is a read-only
+display command.
+
+---
+
+A lightweight alternative to `/vine:resume`. Shows where a feature stands without reconstructing
+full session state or recommending next steps. Useful for a quick check between sessions or
+when deciding which feature to pick up.
+
+## Identify the Feature
+
+Scan for feature directories per the Filtering Convention in `references/STATE.md` (both roots,
+`.archive/` subtrees filtered). Unlike the other enumerating commands, status **includes** resolved
+projects — mark them as such rather than filtering them out.
+
+If a feature path was passed as an argument, use it directly. Otherwise:
+
+- If there's exactly one active feature, use it.
+- If there are multiple features (active or resolved), use `AskUserQuestion` to let the
+  engineer pick. Show resolved projects with a "(resolved)" suffix.
+
+## Display Progress
+
+### With PROJECT-MAP.md
+
+If `.vine/projects/<domain>/<feature-slug>/PROJECT-MAP.md` exists, display it directly —
+it's already designed for at-a-glance scanning:
+
+```
+---
+📊 [Feature Name]
+   Path: .vine/projects/<domain>/<feature-slug>
+
+   VINE Progress: verify ✅ → inquire ✅ → navigate 🚧 → evolve ⬜
+
+[If Milestones table exists:]
+   Milestones:
+   | Phase | Slices | Status | PR |
+   | ... | ... | ... | ... |
+
+[If resolved:]
+   ✅ Resolved
+---
+```
+
+### Without PROJECT-MAP.md (artifact fallback)
+
+If no PROJECT-MAP.md exists, detect progress from which artifacts are present:
+
+```
+---
+📊 [Feature Name]
+   Path: .vine/projects/<domain>/<feature-slug>
+
+   Artifacts found:
+   - CONTEXT.md ✅
+   - SPEC.md ✅ ([N] slices, [M] phase groups)
+   - NAVIGATION.md ✅ ([X of Y] slices complete)
+   - EVOLUTION.md ⬜
+
+[If resolved:]
+   ✅ Resolved
+---
+```
+
+### Multiple Features
+
+If the engineer didn't specify a feature path and there are multiple projects, show a
+compact summary of all active projects before asking which to drill into:
+
+```
+---
+📊 VINE Projects
+
+   payments/webhook-support — navigate 🚧 (4/6 slices)
+   auth/sso-migration — verify ✅ → ready for inquire
+   payments/retry-logic — ✅ Resolved
+
+---
+```
+
+## Important Principles
+
+**Read-only.** Status never writes or modifies anything. No artifact updates, no state changes.
+
+**Fast.** This should complete in seconds. Read PROJECT-MAP.md (or detect artifacts and count
+slice headings) and display — no deep content analysis, no git log archaeology. Counting
+`Complete` slice headings in NAVIGATION.md is the deepest it reads. When a live task list
+exists in the session (e.g., status run alongside an active navigate), status may read it via
+`TaskList` for the slice count instead; in a fresh session there is no list, so it derives
+`[X of Y]` from NAVIGATION.md as usual.
+
+**No recommendations.** Unlike resume, status doesn't suggest next steps or load PAUSE.md.
+It answers "where does this stand?" and nothing more. If the engineer wants guidance, they
+should run `/vine:resume <domain>/<feature-slug>`.


### PR DESCRIPTION
## What
Adds the Claude Code plugin scaffold — a manifest (`.claude-plugin/plugin.json`, name `vine`, v0.4.0) and a self-hosted marketplace (`.claude-plugin/marketplace.json`) — and converts one command (`status`) to the new skill format (`skills/status/SKILL.md`) to prove the packaging works end-to-end. Also lands this cycle's design docs (CONTEXT/SPEC). The existing `commands/vine/` install is untouched and still works.

## Why
VINE installs today via an `npx` file-copy tool; this cycle (#57) repackages it as a native Claude Code plugin. The make-or-break question was whether a plugin-shipped skill still invokes in the familiar colon form `/vine:status` (not `/vine-status`). This PR proves it does — verified by installing the plugin locally and confirming the colon form resolves — so the remaining 10 commands can be converted with confidence.

Refs #57

## How to test
1. From a scratch dir: `claude --plugin-dir <path-to-this-checkout>`
2. Type `/vine:` → confirm `/vine:status` shows in colon form; run `/vine:status workflow/plugin-packaging` and confirm it runs and accepts the argument.
3. `claude plugin validate .` → passes.

## Checklist
- [x] Tested in an actual VINE cycle (plugin installed locally, colon form confirmed)
- [x] Changes are focused on a single concern (Phase 1 scaffold + invocation proof)
- [ ] Docs (README/command files) — deferred to Phase 4 of this cycle (Slice 7–8)

_Note: touches plugin packaging / `skills/` structure — planned roadmap work under #57, not an unsolicited structural change._