### PR TITLE
Release prep: stamp 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,18 @@ All notable changes to VINE are documented here. Format follows [Keep a Changelo
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-23
+
 ### Changed
 - **Shipped skills are self-contained (#142, #141, #138)** — A shipped skill runs with the consuming repo as cwd, so its body no longer cites any VINE-source-internal file. The ~60 dead `references/STATE.md` pointers across 9 skills are removed (runtime-critical content inlined via the operative-copy pattern), payload cross-references use invocable names or `${CLAUDE_PLUGIN_ROOT}/…` instead of bare `agents/…` paths, and `vine:init` no longer writes dead `references/…` pointers into a consuming repo's README/CLAUDE.md. The convention is one rule with three buckets — payload-internal, consumer working tree, VINE-source-internal (forbidden on shipped surfaces) — documented in CLAUDE.md "Skill Authoring Conventions" and `references/CONTRACTS.md` "Path resolution by audience."
 - **`references/STATE.md` renamed to `references/CONTRACTS.md`** — The file carries the artifact templates and cross-cutting conventions, far broader than "state" (which also collided with the session state it merely documents). Live/operative references updated; historical records (this CHANGELOG, dated `.vine/knowledge/` ADRs) left period-accurate.
 
 ### Added
 - **Trellis Check 13: shipped-surface reference guard** — `/trellis` fails the build on any `references/…` path or bare `agents|skills|hooks/` path in `plugins/vine/{skills,agents,hooks}/`, so the self-contained convention can't silently drift back. Bucket-2 consumer paths (`.vine/…`) and name-based agent references don't trip it.
+- **`/release-plugin` contributor command (#144)** — Encodes VINE's release flow (`main`-release / `develop`-integration): bump `plugin.json`, finalize the changelog, and drive the proven stamp→cut two-PR pattern up to the `publish.yml` dispatch, handing the merges and the public publish to the maintainer. Contributor tooling — not part of the shipped plugin payload.
+
+### Fixed
+- **evolve handoff now opens PRs against `develop` (#144)** — The `evolve` context overlay's PR Workflow pins the base branch to `develop` (never `main`), the surface the shipped `evolve` skill defers to when suggesting a PR. `/pr` already targeted `develop`.
 
 ## [0.4.0] - 2026-06-23
 

--- a/plugins/vine/.claude-plugin/plugin.json
+++ b/plugins/vine/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vine",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "VINE — AI-assisted feature development workflow for Claude Code (verify → inquire → navigate → evolve)",
   "author": {
     "name": "moduloMoments",


### PR DESCRIPTION
Stamps **v0.4.1** for release: bumps `plugins/vine/.claude-plugin/plugin.json` to `0.4.1` and finalizes the changelog `[Unreleased]` → `[0.4.1] - 2026-06-23`.

Merge this into `develop`, then cut the `develop`→`main` release PR. Patch release: #143 (self-contained shipped skills + the #141 init bugfix + rename + Check 13 guard) and #144 (the `/release-plugin` command + evolve PR-base fix, contributor-only) — no new shipped capability.

### Release notes (finalized `## [0.4.1]`)

**Changed**
- Shipped skills are self-contained (#142, #141, #138) — no skill body cites a VINE-source-internal file; `vine:init` no longer writes dead `references/…` pointers into consumer repos.
- `references/STATE.md` renamed to `references/CONTRACTS.md`.

**Added**
- Trellis Check 13: shipped-surface reference guard.
- `/release-plugin` contributor command (#144).

**Fixed**
- evolve handoff opens PRs against `develop`, not `main` (#144).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
